### PR TITLE
detail-templates-move-navigation-to-same-level

### DIFF
--- a/comicsdb/templates/comicsdb/arc_detail.html
+++ b/comicsdb/templates/comicsdb/arc_detail.html
@@ -5,6 +5,16 @@
 {% block title %}{{ arc.name }}{% endblock title %}
 
 {% block comic_content %}
+  <!-- arc title -->
+  <nav class="level">
+    <div class="level-left">
+      <div class="level-item">
+        <p class="title">{{ arc }}</p>
+      </div>
+    </div>
+  </nav>
+  <!--  end arc title -->
+
   <!-- arc nav -->
   <nav class="level">
     <div class="level-left">
@@ -41,18 +51,6 @@
             </span>
           </a>
         {% endif %}
-      </div>
-    </div>
-  </nav>
-  <!--  end arc nav -->
-
-  <!-- page header -->
-  <nav class="level">
-    <div class="level-left">
-      <div class="level-item">
-        <div>
-          <p class="title">{{ arc }}</p>
-        </div>
       </div>
     </div>
     <div class="level-right">
@@ -95,7 +93,7 @@
     {% endif %}
     </div>
   </nav>
-  <!-- end of page header -->
+  <!-- end of arc nav -->
 
   <!-- main page content -->
   <div class="columns">

--- a/comicsdb/templates/comicsdb/character_detail.html
+++ b/comicsdb/templates/comicsdb/character_detail.html
@@ -6,6 +6,16 @@
 {% block title %}{{ character.name }}{% endblock title %}
 
 {% block comic_content %}
+  <!-- character title -->
+  <nav class="level">
+    <div class="level-left">
+      <div class="level-item">
+        <p class="title">{{ character }}</p>
+      </div>
+    </div>
+  </nav>
+  <!--  end character title -->
+
   <!-- character nav -->
   <nav class="level">
     <div class="level-left">
@@ -42,18 +52,6 @@
             </span>
           </a>
         {% endif %}
-      </div>
-    </div>
-  </nav>
-  <!--  end character nav -->
-
-  <!-- page header -->
-  <nav class="level">
-    <div class="level-left">
-      <div class="level-item">
-        <div>
-          <p class="title">{{ character }}</p>
-        </div>
       </div>
     </div>
     <div class="level-right">
@@ -96,7 +94,7 @@
     {% endif %}
     </div>
   </nav>
-  <!-- end of page header -->
+  <!-- end of character nav -->
 
   <!-- main page content -->
   <div class="columns">

--- a/comicsdb/templates/comicsdb/creator_detail.html
+++ b/comicsdb/templates/comicsdb/creator_detail.html
@@ -6,6 +6,16 @@
 {% block title %}{{ creator.name }}{% endblock title %}
 
 {% block comic_content %}
+  <!-- creator title -->
+  <nav class="level">
+    <div class="level-left">
+      <div class="level-item">
+        <p class="title">{{ creator.name }}</p>
+      </div>
+    </div>
+  </nav>
+  <!--  end creator title -->
+
   <!-- creator nav -->
   <nav class="level">
     <div class="level-left">
@@ -42,18 +52,6 @@
             </span>
           </a>
         {% endif %}
-      </div>
-    </div>
-  </nav>
-  <!--  end creator nav -->
-
-  <!-- page header -->
-  <nav class="level">
-    <div class="level-left">
-      <div class="level-item">
-        <div>
-          <p class="title">{{ creator.name }}</p>
-        </div>
       </div>
     </div>
     <div class="level-right">
@@ -96,7 +94,7 @@
     {% endif %}
     </div>
   </nav>
-  <!-- end of page header -->
+  <!-- end of creator nav -->
 
   <!-- main page content -->
   <div class="columns">

--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -21,7 +21,17 @@
   </div>
   <!-- end issue cover modal -->
 
-  <!-- series issue nav -->
+  <!-- issue title -->
+  <nav class="level">
+    <div class="level-left">
+      <div class="level-item">
+        <p class="title">{{ issue }}</p>
+      </div>
+    </div>
+  </nav>
+  <!--  end series issue title -->
+
+  <!-- issue navigation -->
   <nav class="level">
     <div class="level-left">
       <div class="level-item">
@@ -47,18 +57,6 @@
               <i class="fas fa-arrow-right"></i>
             </span>
           </a>
-      </div>
-    </div>
-  </nav>
-  <!--  end series issue nav -->
-
-  <!-- page header -->
-  <nav class="level">
-    <div class="level-left">
-      <div class="level-item">
-        <div>
-          <p class="title">{{ issue }}</p>
-        </div>
       </div>
     </div>
     <div class="level-right">
@@ -104,7 +102,7 @@
     {% endif %}
     </div>
   </nav>
-  <!-- end of page header -->
+  <!-- end of issue navigation -->
 
   <!-- main page content -->
   <div class="columns">

--- a/comicsdb/templates/comicsdb/publisher_detail.html
+++ b/comicsdb/templates/comicsdb/publisher_detail.html
@@ -5,6 +5,16 @@
 {% block title %}{{ publisher.name }}{% endblock title %}
 
 {% block comic_content %}
+  <!-- publisher title -->
+  <nav class="level">
+    <div class="level-left">
+      <div class="level-item">
+        <div><p class="title">{{ publisher }}</p></div>
+      </div>
+    </div>
+  </nav>
+  <!--  end publisher title -->
+
   <!-- publisher nav -->
   <nav class="level">
     <div class="level-left">
@@ -41,16 +51,6 @@
             </span>
           </a>
         {% endif %}
-      </div>
-    </div>
-  </nav>
-  <!--  end publisher nav -->
-
-  <!-- page header -->
-  <nav class="level">
-    <div class="level-left">
-      <div class="level-item">
-        <div><p class="title">{{ publisher }}</p></div>
       </div>
     </div>
     <div class="level-right">
@@ -96,7 +96,7 @@
       {% endif %}
     </div>
   </nav>
-  <!-- end of page header -->
+  <!-- end of publisher nav -->
 
   <!-- main page content -->
   <div class="columns">

--- a/comicsdb/templates/comicsdb/series_detail.html
+++ b/comicsdb/templates/comicsdb/series_detail.html
@@ -5,6 +5,16 @@
 {% block title %}{{ series.name }}{% endblock title %}
 
 {% block comic_content %}
+  <!-- series title -->
+  <nav class="level">
+    <div class="level-left">
+      <div class="level-item">
+        <p class="title">{{ series }}</p>
+      </div>
+    </div>
+  </nav>
+  <!--  end series title -->
+
   <!-- series nav -->
   <nav class="level">
     <div class="level-left">
@@ -41,18 +51,6 @@
             </span>
           </a>
         {% endif %}
-      </div>
-    </div>
-  </nav>
-  <!--  end series nav -->
-
-  <!-- page header -->
-  <nav class="level">
-    <div class="level-left">
-      <div class="level-item">
-        <div>
-          <p class="title">{{ series }}</p>
-        </div>
       </div>
     </div>
     <div class="level-right">
@@ -103,7 +101,7 @@
       {% endif %}
     </div>
   </nav>
-  <!-- end of page header -->
+  <!-- end of series nav -->
 
   <!-- main page content -->
   <div class="columns">

--- a/comicsdb/templates/comicsdb/team_detail.html
+++ b/comicsdb/templates/comicsdb/team_detail.html
@@ -5,6 +5,16 @@
 {% block title %}{{ team.name }}{% endblock title %}
 
 {% block comic_content %}
+  <!-- team title -->
+  <nav class="level">
+    <div class="level-left">
+      <div class="level-item">
+        <p class="title">{{ team }}</p>
+      </div>
+    </div>
+  </nav>
+  <!--  end team title -->
+
   <!-- team nav -->
   <nav class="level">
     <div class="level-left">
@@ -41,18 +51,6 @@
             </span>
           </a>
         {% endif %}
-      </div>
-    </div>
-  </nav>
-  <!--  end team nav -->
-
-  <!-- page header -->
-  <nav class="level">
-    <div class="level-left">
-      <div class="level-item">
-        <div>
-          <p class="title">{{ team }}</p>
-        </div>
       </div>
     </div>
     <div class="level-right">
@@ -95,7 +93,7 @@
     {% endif %}
     </div>
   </nav>
-  <!-- end of page header -->
+  <!-- end of team nav -->
 
   <!-- main page content -->
   <div class="columns">


### PR DESCRIPTION
Move detail templates navigation to the same level. This will help improve readability of items with long titles.

May need to look at better formatting of titles to improve readability.