### PR TITLE
Add user permission when creating account

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -54,13 +54,13 @@ class CustomUserAdmin(UserAdmin):
 
     @admin.action(description="Grant 'add creator' permission to user")
     def grant_add_creator_perm(self, request, queryset) -> None:
-        count = 0
         try:
             permission = Permission.objects.get(name="Can add creator")
         except Permission.DoesNotExist:
             permission = None
 
         if permission is not None:
+            count = 0
             for i in queryset:
                 modified = False
                 if permission not in i.user_permissions.all():

--- a/users/views.py
+++ b/users/views.py
@@ -2,6 +2,7 @@ import logging
 
 from django.contrib import messages
 from django.contrib.auth import login, update_session_auth_hash
+from django.contrib.auth.models import Permission
 from django.contrib.auth.views import PasswordChangeView
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.sites.shortcuts import get_current_site
@@ -41,6 +42,13 @@ def activate(request, uidb64, token):
 
     user.is_active = True
     user.email_confirmed = True
+    # Needed so the user can add new creators in the Issue form.
+    try:
+        permission = Permission.objects.get(name="Can add creator")
+    except Permission.DoesNotExist:
+        permission = None
+    if permission is not None:
+        user.user_permissions.add(permission)
     user.save()
     login(request, user)
     # Send pushover notification tha user activated account


### PR DESCRIPTION
This pull request will add a `create creator` permission when a user creates an account on the site. This will allow them to create new creators on the Issue form credits section.

**Existing** users will need to be updated by the admin with the admin action to grant this permission.