### PR TITLE
Don't allow collections to have associated series

### DIFF
--- a/comicsdb/forms/series.py
+++ b/comicsdb/forms/series.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm
+from django.forms import ModelForm, ValidationError
 from django_select2 import forms as s2forms
 
 from comicsdb.models import Series
@@ -43,23 +43,37 @@ class SeriesForm(ModelForm):
             ),
             "genres": "Hold down “Control”, or “Command” on a Mac, to select more than one.",
             "collection": (
-                "Whether a series has a collection title. Normally this only applies to Trade Paperbacks. "  # NOQA: E501
-                "For example, the 2015 Deathstroke Trade Paperback which has a collection title of 'Gods of War'."  # NOQA: E501
+                "Whether a series has a collection title. "
+                "Normally this only applies to Trade Paperbacks. "
+                "For example, the 2015 Deathstroke Trade Paperback which has a collection "
+                "title of 'Gods of War'."
             ),
         }
         labels = {"associated": "Associated Series", "collection": "Allow collection title?"}
 
-    field_order = [
-        "name",
-        "sort_name",
-        "volume",
-        "year_began",
-        "year_end",
-        "series_type",
-        "collection",
-        "publisher",
-        "cv_id",
-        "desc",
-        "genres",
-        "associated",
-    ]
+        field_order = [
+            "name",
+            "sort_name",
+            "volume",
+            "year_began",
+            "year_end",
+            "series_type",
+            "collection",
+            "publisher",
+            "cv_id",
+            "desc",
+            "genres",
+            "associated",
+        ]
+
+    def clean_associated(self):
+        assoc = self.cleaned_data["associated"]
+        if assoc:
+            series_type = self.cleaned_data["series_type"]
+            # If adding an associated series and self.series_type is a TPB or HC
+            # raise a validation error.
+            if series_type.id in [8, 10] and assoc:
+                raise ValidationError(
+                    "Collections are not allowed to have an associated series."
+                )
+        return assoc

--- a/comicsdb/forms/series.py
+++ b/comicsdb/forms/series.py
@@ -72,7 +72,7 @@ class SeriesForm(ModelForm):
             series_type = self.cleaned_data["series_type"]
             # If adding an associated series and self.series_type is a TPB or HC
             # raise a validation error.
-            if series_type.id in [8, 10] and assoc:
+            if series_type.id in [8, 10]:
                 raise ValidationError(
                     "Collections are not allowed to have an associated series."
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ line-length = 95
 show-fixes = true
 target-version = "py310"
 lint.ignore = ["A003", "RUF012", "SLF001", "ISC001"]
-select = [
+lint.select = [
     "A",
     "B",
     "BLE",


### PR DESCRIPTION
Add validation to the series form to prevent collection from having associated series added.