### PR TITLE
Add `Series` form validation for `cv_id` field

### DIFF
--- a/comicsdb/forms/series.py
+++ b/comicsdb/forms/series.py
@@ -3,6 +3,10 @@ from django_select2 import forms as s2forms
 
 from comicsdb.models import Series
 
+# Series_Type objects id's
+TPB = 10
+HC = 8
+
 
 class SeriesWidget(s2forms.ModelSelect2Widget):
     search_fields = ["name__icontains"]
@@ -66,13 +70,27 @@ class SeriesForm(ModelForm):
             "associated",
         ]
 
-    def clean_associated(self):
+    def clean_cv_id(self) -> any:
+        cvid = self.cleaned_data["cv_id"]
+        if cvid:
+            series_type = self.cleaned_data["series_type"]
+            # Don't cv_id for Trade Paperbacks. Refer to:
+            # https://github.com/bpepple/metron/issues/219
+            if series_type.id == TPB:
+                msg = (
+                    "Adding a Comic Vine ID  is not allowed for Trade Paperbacks, "
+                    "due to the consolidation work being done there."
+                )
+                raise ValidationError(msg)
+        return cvid
+
+    def clean_associated(self) -> any:
         assoc = self.cleaned_data["associated"]
         if assoc:
             series_type = self.cleaned_data["series_type"]
             # If adding an associated series and self.series_type is a TPB or HC
             # raise a validation error.
-            if series_type.id in [8, 10]:
+            if series_type.id in [HC, TPB]:
                 raise ValidationError(
                     "Collections are not allowed to have an associated series."
                 )

--- a/comicsdb/forms/series.py
+++ b/comicsdb/forms/series.py
@@ -74,7 +74,7 @@ class SeriesForm(ModelForm):
         cvid = self.cleaned_data["cv_id"]
         if cvid:
             series_type = self.cleaned_data["series_type"]
-            # Don't cv_id for Trade Paperbacks. Refer to:
+            # Don't allow cv_id information for Trade Paperbacks. Refer to:
             # https://github.com/bpepple/metron/issues/219
             if series_type.id == TPB:
                 msg = (


### PR DESCRIPTION
Comic Vine is consolidating their Series Trade Paperback's, and the id's of those series that were removed are being re-used for new series.

To prevent potential matching problems, I'm adding a field validation to the `Series` form to prevent information from being added to the `cv_id` field for Trade Paperbacks.

When this work is done at Comic Vine, this validation can be removed.