### PR TITLE
Add reprint story titles to Collections

### DIFF
--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -95,7 +95,7 @@
                             </a>
                         </p>
                         {% if issue.series.series_type.name == "Trade Paperback" or issue.series.series_type.name == "Omnibus" or issue.series.series_type.name == "Hardcover" %}
-                            {% if issue.reprints.exists and not issue.characters.exists and not issue.teams.exists %}
+                            {% if issue.reprints.exists and not issue.characters.exists and not issue.teams.exists and not issue.name|length > 0 %}
                                 <form method="post"
                                       action="{% url 'issue:sync-reprints' slug=issue.slug %}">
                                     {% csrf_token %}


### PR DESCRIPTION
This PR will add the stories from the reprinted issue to the Collected Edition.

This function will work if the tpb has *no* character. *no* teams, and *no* stories

If the reprint issue has no story, "[Untitled]" is added.