### PR TITLE
Use HTMX to update Recently Edited Issues

### DIFF
--- a/comicsdb/templates/comicsdb/home.html
+++ b/comicsdb/templates/comicsdb/home.html
@@ -209,18 +209,11 @@
 {% if recently_edited %}
     <section class="section">
         <div class="container">
-            <div class="box">
-                <header class="block">
-                    <h2 class="title is-4">Recently Edited Issues</h2>
-                    <p class="subtitle is-7">
-                        <time datetime="{{ updated|date:'c' }}">
-                            Last updated: {{ updated }}
-                        </time>
-                    </p>
-                </header>
-                {# Use the reusable issue card grid partial #}
-                {% include "comicsdb/partials/issue_card_grid.html" with items=recently_edited %}
-            </div>
+            <div class="box"
+                 hx-get="{% url 'recently-edited' %}"
+                 hx-trigger="every 120s"
+                 hx-swap="innerHTML"
+                 hx-indicator="#refresh-indicator">{% include "comicsdb/partials/recently_edited_section.html" %}</div>
         </div>
     </section>
 {% endif %}

--- a/comicsdb/templates/comicsdb/partials/recently_edited_section.html
+++ b/comicsdb/templates/comicsdb/partials/recently_edited_section.html
@@ -1,0 +1,19 @@
+{% comment %}
+    Recently edited issues section partial
+    Usage: {% include "comicsdb/partials/recently_edited_section.html" %}
+{% endcomment %}
+<header class="block">
+    <h2 class="title is-4">Recently Edited Issues</h2>
+    <p class="subtitle is-7">
+        <time datetime="{{ updated|date:'c' }}">
+            Last updated: {{ updated }}
+        </time>
+        <span id="refresh-indicator" class="htmx-indicator ml-2">
+            <span class="icon is-small">
+                <i class="fas fa-sync fa-spin"></i>
+            </span>
+        </span>
+    </p>
+</header>
+{# Use the reusable issue card grid partial #}
+{% include "comicsdb/partials/issue_card_grid.html" with items=recently_edited %}

--- a/comicsdb/urls/home.py
+++ b/comicsdb/urls/home.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from comicsdb.views.home import HomePageView
+from comicsdb.views.home import HomePageView, recently_edited_issues
 from comicsdb.views.statistics import statistics
 
 app_name = ""
 urlpatterns = [
     path("", HomePageView.as_view(), name="home"),
     path("statistics/", statistics, name="statistics"),
+    path("recently-edited/", recently_edited_issues, name="recently-edited"),
 ]

--- a/comicsdb/views/home.py
+++ b/comicsdb/views/home.py
@@ -1,12 +1,37 @@
 from datetime import datetime
 
 from django.core.cache import cache
+from django.shortcuts import render
 from django.views.generic.base import TemplateView
 
 from comicsdb.models import Issue
 
 # Cache time to live is 30 minutes.
 CACHE_TTL = 60 * 30
+
+
+def recently_edited_issues(request):
+    """HTMX endpoint for recently edited issues - always returns fresh data."""
+    update_time = datetime.now()
+
+    recently_edited = (
+        Issue.objects.prefetch_related("series", "series__series_type")
+        .order_by("-modified")
+        .all()[:12]
+    )
+
+    # Update cache so subsequent page loads get fresh data
+    cache.set("home_updated", update_time, CACHE_TTL)
+    cache.set("recently_edited", recently_edited, CACHE_TTL)
+
+    return render(
+        request,
+        "comicsdb/partials/recently_edited_section.html",
+        {
+            "recently_edited": recently_edited,
+            "updated": update_time,
+        },
+    )
 
 
 class HomePageView(TemplateView):

--- a/static/site/css/base.css
+++ b/static/site/css/base.css
@@ -294,3 +294,44 @@ a:focus-visible {
 .section + .section {
     padding-top: 3rem;
 }
+
+/* ========================================
+   HTMX Enhancements
+   ======================================== */
+
+/* Hide HTMX loading indicators by default */
+.htmx-indicator {
+    display: none;
+}
+
+/* Show loading indicators during HTMX requests */
+.htmx-request .htmx-indicator,
+.htmx-request.htmx-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Smooth fade transition for HTMX swaps */
+.htmx-swapping {
+    opacity: 0;
+    transition: opacity 200ms ease-out;
+}
+
+.htmx-settling {
+    opacity: 1;
+    transition: opacity 200ms ease-in;
+}
+
+/* Loading spinner color */
+.htmx-indicator .fa-sync {
+    color: hsl(0, 0%, 60%);
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+    .htmx-swapping,
+    .htmx-settling {
+        transition: none;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,6 +37,10 @@
         <link rel="stylesheet" href="{% static 'site/css/base.css' %}">
         {% block headcss %}{% endblock %}
         {# Head Scripts #}
+        {# HTMX for dynamic content loading #}
+        <script src="https://unpkg.com/htmx.org@2.0.4"
+                integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"
+                crossorigin="anonymous"></script>
         {% block headscripts %}{% endblock %}
     </head>
     <body class="has-navbar-fixed-top">


### PR DESCRIPTION
This PR updates the home page template to use HTMX to refresh the Recently Edited Issue section.

The HTMX auto-refresh effectively shortens the cache lifetime from 30 minutes to 2 minutes for users who stay on the homepage, while still providing the performance benefit of caching for new visitors.