### PR TITLE
Use HTMX to provide live statistics

### DIFF
--- a/comicsdb/templates/comicsdb/partials/statistics_charts.html
+++ b/comicsdb/templates/comicsdb/partials/statistics_charts.html
@@ -1,0 +1,49 @@
+{% comment %}
+    Statistics charts section partial
+    Usage: {% include "comicsdb/partials/statistics_charts.html" %}
+{% endcomment %}
+{# Charts Section #}
+<section class="section">
+    <h2 class="title is-4 has-text-centered mb-5">
+        Statistical Analysis
+        <span id="charts-refresh-indicator" class="htmx-indicator ml-2">
+            <span class="icon is-small">
+                <i class="fas fa-sync fa-spin"></i>
+            </span>
+        </span>
+    </h2>
+    {# Issues by Year #}
+    <div class="box mb-5">
+        <div class="content">{{ year_count }}</div>
+    </div>
+    {# Issues by Publisher #}
+    <div class="box mb-5">
+        <div class="content">{{ publisher_count }}</div>
+    </div>
+    {# Issue Trends #}
+    <div class="columns is-multiline mb-5">
+        <div class="column is-half">
+            <div class="box">
+                <div class="content">{{ daily_chart }}</div>
+            </div>
+        </div>
+        <div class="column is-half">
+            <div class="box">
+                <div class="content">{{ monthly_chart }}</div>
+            </div>
+        </div>
+    </div>
+    {# Creator and Character Trends #}
+    <div class="columns is-multiline">
+        <div class="column is-half">
+            <div class="box">
+                <div class="content">{{ creator_chart }}</div>
+            </div>
+        </div>
+        <div class="column is-half">
+            <div class="box">
+                <div class="content">{{ character_chart }}</div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/comicsdb/templates/comicsdb/partials/statistics_totals.html
+++ b/comicsdb/templates/comicsdb/partials/statistics_totals.html
@@ -1,0 +1,66 @@
+{% comment %}
+    Statistics totals section partial
+    Usage: {% include "comicsdb/partials/statistics_totals.html" %}
+{% endcomment %}
+{% load humanize %}
+<header class="block has-text-centered">
+    <h1 class="title is-3">Metron Database Statistics</h1>
+    <p class="subtitle is-6 has-text-grey">
+        Last Updated: <time datetime="{{ update_time|date:'c' }}">{{ update_time }}</time>
+        <span id="totals-refresh-indicator" class="htmx-indicator ml-2">
+            <span class="icon is-small">
+                <i class="fas fa-sync fa-spin"></i>
+            </span>
+        </span>
+    </p>
+</header>
+{# Summary Totals #}
+<section class="section">
+    <div class="box has-background-light">
+        <h2 class="title is-4 has-text-centered has-text-dark mb-5">Database Totals</h2>
+        <div class="columns is-multiline">
+            <div class="column is-3">
+                <div class="box has-text-centered">
+                    <p class="heading">Publishers</p>
+                    <p class="title is-3 has-text-primary">{{ publishers_total|intcomma }}</p>
+                </div>
+            </div>
+            <div class="column is-3">
+                <div class="box has-text-centered">
+                    <p class="heading">Series</p>
+                    <p class="title is-3 has-text-info">{{ series_total|intcomma }}</p>
+                </div>
+            </div>
+            <div class="column is-3">
+                <div class="box has-text-centered">
+                    <p class="heading">Issues</p>
+                    <p class="title is-3 has-text-link">{{ issues_total|intcomma }}</p>
+                </div>
+            </div>
+            <div class="column is-3">
+                <div class="box has-text-centered">
+                    <p class="heading">Characters</p>
+                    <p class="title is-3 has-text-success">{{ characters_total|intcomma }}</p>
+                </div>
+            </div>
+            <div class="column is-3">
+                <div class="box has-text-centered">
+                    <p class="heading">Creators</p>
+                    <p class="title is-3 has-text-warning">{{ creators_total|intcomma }}</p>
+                </div>
+            </div>
+            <div class="column is-3">
+                <div class="box has-text-centered">
+                    <p class="heading">Teams</p>
+                    <p class="title is-3 has-text-danger">{{ teams_total|intcomma }}</p>
+                </div>
+            </div>
+            <div class="column is-3">
+                <div class="box has-text-centered">
+                    <p class="heading">Story Arcs</p>
+                    <p class="title is-3 has-text-grey-dark">{{ arcs_total|intcomma }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/comicsdb/templates/comicsdb/statistics.html
+++ b/comicsdb/templates/comicsdb/statistics.html
@@ -9,108 +9,23 @@
     Statistics - Metron
 {% endblock title %}
 {% block content %}
-    {# Page Header #}
-    <header class="block has-text-centered">
-        <h1 class="title is-3">Metron Database Statistics</h1>
-        <p class="subtitle is-6 has-text-grey">
-            Last Updated: <time datetime="{{ update_time|date:'c' }}">{{ update_time }}</time>
-        </p>
-    </header>
-    {# Summary Totals #}
-    <section class="section">
-        <div class="box has-background-light">
-            <h2 class="title is-4 has-text-centered has-text-dark mb-5">Database Totals</h2>
-            <div class="columns is-multiline">
-                <div class="column is-3">
-                    <div class="box has-text-centered">
-                        <p class="heading">Publishers</p>
-                        <p class="title is-3 has-text-primary">{{ publishers_total|intcomma }}</p>
-                    </div>
-                </div>
-                <div class="column is-3">
-                    <div class="box has-text-centered">
-                        <p class="heading">Series</p>
-                        <p class="title is-3 has-text-info">{{ series_total|intcomma }}</p>
-                    </div>
-                </div>
-                <div class="column is-3">
-                    <div class="box has-text-centered">
-                        <p class="heading">Issues</p>
-                        <p class="title is-3 has-text-link">{{ issues_total|intcomma }}</p>
-                    </div>
-                </div>
-                <div class="column is-3">
-                    <div class="box has-text-centered">
-                        <p class="heading">Characters</p>
-                        <p class="title is-3 has-text-success">{{ characters_total|intcomma }}</p>
-                    </div>
-                </div>
-                <div class="column is-3">
-                    <div class="box has-text-centered">
-                        <p class="heading">Creators</p>
-                        <p class="title is-3 has-text-warning">{{ creators_total|intcomma }}</p>
-                    </div>
-                </div>
-                <div class="column is-3">
-                    <div class="box has-text-centered">
-                        <p class="heading">Teams</p>
-                        <p class="title is-3 has-text-danger">{{ teams_total|intcomma }}</p>
-                    </div>
-                </div>
-                <div class="column is-3">
-                    <div class="box has-text-centered">
-                        <p class="heading">Story Arcs</p>
-                        <p class="title is-3 has-text-grey-dark">{{ arcs_total|intcomma }}</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    {# Charts Section #}
-    <section class="section">
-        <h2 class="title is-4 has-text-centered mb-5">Statistical Analysis</h2>
-        {# Issues by Year #}
-        <div class="box mb-5">
-            <div class="content">{{ year_count }}</div>
-        </div>
-        {# Issues by Publisher #}
-        <div class="box mb-5">
-            <div class="content">{{ publisher_count }}</div>
-        </div>
-        {# Issue Trends #}
-        <div class="columns is-multiline mb-5">
-            <div class="column is-half">
-                <div class="box">
-                    <div class="content">{{ daily_chart }}</div>
-                </div>
-            </div>
-            <div class="column is-half">
-                <div class="box">
-                    <div class="content">{{ monthly_chart }}</div>
-                </div>
-            </div>
-        </div>
-        {# Creator and Character Trends #}
-        <div class="columns is-multiline">
-            <div class="column is-half">
-                <div class="box">
-                    <div class="content">{{ creator_chart }}</div>
-                </div>
-            </div>
-            <div class="column is-half">
-                <div class="box">
-                    <div class="content">{{ character_chart }}</div>
-                </div>
-            </div>
-        </div>
-    </section>
+    {# Database Totals Section with HTMX auto-refresh #}
+    <div hx-get="{% url 'statistics-totals' %}"
+         hx-trigger="load, every 30s"
+         hx-swap="outerHTML"
+         hx-indicator="#totals-refresh-indicator">{% include "comicsdb/partials/statistics_totals.html" %}</div>
+    {# Charts Section with HTMX auto-refresh #}
+    <div hx-get="{% url 'statistics-charts' %}"
+         hx-trigger="load, every 30s"
+         hx-swap="outerHTML"
+         hx-indicator="#charts-refresh-indicator">{% include "comicsdb/partials/statistics_charts.html" %}</div>
     {# Information Box #}
     <section class="section">
         <div class="notification is-info is-light">
             <div class="content">
                 <p class="has-text-weight-bold">About These Statistics</p>
                 <p>
-                    These statistics are automatically generated from the Metron database and are updated every 30 minutes.
+                    These statistics are automatically generated from the Metron database and update live every 30 seconds.
                     They represent the collective efforts of our community in building a comprehensive comic book database.
                 </p>
             </div>

--- a/comicsdb/urls/home.py
+++ b/comicsdb/urls/home.py
@@ -1,11 +1,13 @@
 from django.urls import path
 
 from comicsdb.views.home import HomePageView, recently_edited_issues
-from comicsdb.views.statistics import statistics
+from comicsdb.views.statistics import statistics, statistics_charts, statistics_totals
 
 app_name = ""
 urlpatterns = [
     path("", HomePageView.as_view(), name="home"),
     path("statistics/", statistics, name="statistics"),
+    path("statistics/totals/", statistics_totals, name="statistics-totals"),
+    path("statistics/charts/", statistics_charts, name="statistics-charts"),
     path("recently-edited/", recently_edited_issues, name="recently-edited"),
 ]

--- a/comicsdb/views/statistics.py
+++ b/comicsdb/views/statistics.py
@@ -1,132 +1,152 @@
 from datetime import datetime
 
 from chartkick.django import ColumnChart, PieChart
-from django.core.cache import cache
 from django.db.models import Count
 from django.db.models.functions import TruncDate, TruncMonth, TruncYear
 from django.shortcuts import render
 
 from comicsdb.models import Arc, Character, Creator, Issue, Publisher, Series, Team
 
-# Cache time to live is 30 minutes.
-CACHE_TTL = 60 * 30
-
 
 def _create_year_count_dict():
-    years_count = cache.get("year_count_dict")
-    if not years_count:
-        years_count = (
-            Issue.objects.annotate(year=TruncYear("created_on"))
-            .values("year")
-            .annotate(c=Count("year"))
-            .order_by("year")
-        )
-        cache.set("year_count_dict", years_count, CACHE_TTL)
-
+    years_count = (
+        Issue.objects.annotate(year=TruncYear("created_on"))
+        .values("year")
+        .annotate(c=Count("year"))
+        .order_by("year")
+    )
     return {year_count["year"].strftime("%Y"): year_count["c"] for year_count in years_count}
 
 
 def _create_pub_dict() -> dict[str, int]:
-    publishers = cache.get("publishers")
-    if not publishers:
-        publishers = Publisher.objects.annotate(num_issues=Count("series__issues")).values(
-            "name", "num_issues"
-        )
-        cache.set("publishers", publishers, CACHE_TTL)
+    publishers = Publisher.objects.annotate(num_issues=Count("series__issues")).values(
+        "name", "num_issues"
+    )
     return {publisher["name"]: publisher["num_issues"] for publisher in publishers}
 
 
 def _create_monthly_issue_dict() -> dict[str, int]:
-    monthly_issues = cache.get("monthly_issues")
-    if not monthly_issues:
-        monthly_issues = (
-            Issue.objects.annotate(month=TruncMonth("created_on"))
-            .values("month")
-            .annotate(c=Count("month"))
-            .order_by("-month")[:12]
-        )
-        cache.set("monthly_issues", monthly_issues, CACHE_TTL)
-
+    monthly_issues = (
+        Issue.objects.annotate(month=TruncMonth("created_on"))
+        .values("month")
+        .annotate(c=Count("month"))
+        .order_by("-month")[:12]
+    )
     return {issue["month"].strftime("%b"): issue["c"] for issue in monthly_issues[::-1]}
 
 
 def _create_daily_issue_dict() -> dict[str, int]:
-    daily_issues = cache.get("daily_issues")
-    if not daily_issues:
-        daily_issues = (
-            Issue.objects.annotate(day=TruncDate("created_on"))
-            .values("day")
-            .annotate(c=Count("day"))
-            .order_by("-day")[:30]
-        )
-        cache.set("daily_issues", daily_issues, CACHE_TTL)
-
+    daily_issues = (
+        Issue.objects.annotate(day=TruncDate("created_on"))
+        .values("day")
+        .annotate(c=Count("day"))
+        .order_by("-day")[:30]
+    )
     return {issue["day"].strftime("%m/%d"): issue["c"] for issue in daily_issues[::-1]}
 
 
 def _create_creator_dict() -> dict[str, int]:
-    creators = cache.get("creators")
-    if not creators:
-        creators = (
-            Creator.objects.annotate(month=TruncMonth("created_on"))
-            .values("month")
-            .annotate(c=Count("month"))
-            .order_by("-month")[:12]
-        )
-        cache.set("creators", creators, CACHE_TTL)
-
+    creators = (
+        Creator.objects.annotate(month=TruncMonth("created_on"))
+        .values("month")
+        .annotate(c=Count("month"))
+        .order_by("-month")[:12]
+    )
     return {creator["month"].strftime("%b"): creator["c"] for creator in creators[::-1]}
 
 
 def _create_character_dict() -> dict[str, int]:
-    characters = cache.get("characters")
-    if not characters:
-        characters = (
-            Character.objects.annotate(month=TruncMonth("created_on"))
-            .values("month")
-            .annotate(c=Count("month"))
-            .order_by("-month")[:12]
-        )
-        cache.set("characters", characters, CACHE_TTL)
-
+    characters = (
+        Character.objects.annotate(month=TruncMonth("created_on"))
+        .values("month")
+        .annotate(c=Count("month"))
+        .order_by("-month")[:12]
+    )
     return {character["month"].strftime("%b"): character["c"] for character in characters[::-1]}
 
 
-def statistics(request):
-    # Resource totals
-    cache_keys = [
-        "stats_update_time",
-        "publishers_total",
-        "series_total",
-        "issue_total",
-        "characters_total",
-        "creators_total",
-        "teams_total",
-        "arcs_total",
-    ]
-    cache_values = cache.get_many(cache_keys)
+def statistics_totals(request):
+    """HTMX endpoint for database totals - always returns fresh data."""
+    update_time = datetime.now()
 
-    update_time = cache_values.get("stats_update_time")
-    if not update_time:
-        update_time = datetime.now()
-        cache.set("stats_update_time", update_time, CACHE_TTL)
-
-    model_cache_map = {
-        "publishers_total": Publisher,
-        "series_total": Series,
-        "issue_total": Issue,
-        "characters_total": Character,
-        "creators_total": Creator,
-        "teams_total": Team,
-        "arcs_total": Arc,
+    totals = {
+        "publishers_total": Publisher.objects.count(),
+        "series_total": Series.objects.count(),
+        "issues_total": Issue.objects.count(),
+        "characters_total": Character.objects.count(),
+        "creators_total": Creator.objects.count(),
+        "teams_total": Team.objects.count(),
+        "arcs_total": Arc.objects.count(),
     }
 
-    totals = {}
-    for key, model in model_cache_map.items():
-        totals[key] = cache_values.get(key)
-        if totals[key] is None:
-            totals[key] = model.objects.count()
-            cache.set(key, totals[key], CACHE_TTL)
+    return render(
+        request,
+        "comicsdb/partials/statistics_totals.html",
+        {
+            "update_time": update_time,
+            **totals,
+        },
+    )
+
+
+def statistics_charts(request):
+    """HTMX endpoint for statistics charts - always returns fresh data."""
+    pub_chart = PieChart(
+        _create_pub_dict(),
+        title="Percentage of Issues by Publisher",
+        thousands=",",
+        legend=False,
+    )
+    year_chart = PieChart(
+        _create_year_count_dict(), title="Number of Issues Added per Year", thousands=","
+    )
+    daily_chart = ColumnChart(
+        _create_daily_issue_dict(),
+        title="Number of Issues for the last 30 days",
+        thousands=",",
+    )
+    monthly_chart = ColumnChart(
+        _create_monthly_issue_dict(), title="Number of Issues Added by Month", thousands=","
+    )
+    creator_chart = ColumnChart(
+        _create_creator_dict(),
+        title="Number of Creators Added by Month",
+        thousands=",",
+    )
+    character_chart = ColumnChart(
+        _create_character_dict(),
+        title="Number of Characters Added by Month",
+        thousands=",",
+    )
+
+    return render(
+        request,
+        "comicsdb/partials/statistics_charts.html",
+        {
+            "publisher_count": pub_chart,
+            "year_count": year_chart,
+            "daily_chart": daily_chart,
+            "monthly_chart": monthly_chart,
+            "creator_chart": creator_chart,
+            "character_chart": character_chart,
+        },
+    )
+
+
+def statistics(request):
+    """Main statistics page - uses HTMX for live updates."""
+    update_time = datetime.now()
+
+    # Get initial data for first page load
+    totals = {
+        "publishers_total": Publisher.objects.count(),
+        "series_total": Series.objects.count(),
+        "issues_total": Issue.objects.count(),
+        "characters_total": Character.objects.count(),
+        "creators_total": Creator.objects.count(),
+        "teams_total": Team.objects.count(),
+        "arcs_total": Arc.objects.count(),
+    }
 
     # Time based statistics
     pub_chart = PieChart(
@@ -167,13 +187,7 @@ def statistics(request):
             "monthly_chart": monthly_chart,
             "creator_chart": creator_chart,
             "character_chart": character_chart,
-            "publishers_total": totals["publishers_total"],
-            "series_total": totals["series_total"],
-            "issues_total": totals["issue_total"],
-            "characters_total": totals["characters_total"],
-            "creators_total": totals["creators_total"],
-            "teams_total": totals["teams_total"],
-            "arcs_total": totals["arcs_total"],
             "update_time": update_time,
+            **totals,
         },
     )


### PR DESCRIPTION
This PR adds live update to the Statistics page.

Changes:
- Removed cache logic
- Added two new HTMX endpoint views so they refresh independently:
  - statistics_totals(): Returns live database totals (Publishers, Series, Issues, Characters, Creators, Teams, Arcs)
  - statistics_charts(): Returns live chart data (all 6 charts)
- Created partial templates for `statistics_totals` and `statistics_charts`
- Refactored `statistics.html` to use HTMX attributes for live updates every 30 seconds
- Add some loading indicators that will appear during refresh