### PR TITLE
Fixed space after entity name if no entities present

### DIFF
--- a/comicsdb/templates/comicsdb/partials/empty_state.html
+++ b/comicsdb/templates/comicsdb/partials/empty_state.html
@@ -15,8 +15,7 @@
                     <i class="fas fa-inbox fa-3x"></i>
                 </span>
                 <h2 class="title is-4">
-                    No {{ item_type }}
-                    {% if item_type|lower != "series" %}s{% endif %}
+                    No {{ item_type }}{% if item_type|lower != "series" %}s{% endif %}
                     Available
                 </h2>
                 <p class="subtitle is-6 has-text-grey">


### PR DESCRIPTION
Fixed this:
<img width="381" height="333" alt="изображение" src="https://github.com/user-attachments/assets/91f24a53-0e3e-42e5-8548-bc2f241d4280" />

Into this:
<img width="492" height="330" alt="изображение" src="https://github.com/user-attachments/assets/7453b975-a444-4d2a-b279-c46e5b030595" />
