### PR TITLE
Fixed dropdown menus in navbar not working on touch devices

### DIFF
--- a/static/site/js/touch-interface-dropdown.js
+++ b/static/site/js/touch-interface-dropdown.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', function () {
+    // check if touch device, return if not
+    const isTouchDevice = matchMedia('(hover: none)').matches;
+
+    if (!isTouchDevice) return;
+
+    // Find all hoverable dropdowns and disable hover for them
+    const dropdowns = document.querySelectorAll('.navbar-item.has-dropdown.is-hoverable');
+
+    dropdowns.forEach(dropdown => {
+        dropdown.classList.remove('is-hoverable');
+
+        const link = dropdown.querySelector('.navbar-link');
+
+        // Toggle dropdown on touch and close all other dropdowns
+        link.addEventListener('click', function (event) {
+            event.preventDefault();
+
+            dropdowns.forEach(d => {
+                if (d !== dropdown) d.classList.remove('is-active');
+            });
+
+            dropdown.classList.toggle('is-active');
+        });
+    });
+
+    // If touched anywhere else, close all dropdowns
+    document.addEventListener('click', function (event) {
+        if (!event.target.closest('.navbar-item.has-dropdown')) {
+            dropdowns.forEach(d => d.classList.remove('is-active'));
+        }
+    });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,7 +37,9 @@
         <link rel="stylesheet" href="{% static 'site/css/base.css' %}">
         {% block headcss %}{% endblock %}
         {# Head Scripts #}
-        {% block headscripts %}{% endblock %}
+        {% block headscripts %}
+        <script src="{% static 'site/js/touch-interface-dropdown.js' %}"></script>
+        {% endblock %}
     </head>
     <body class="has-navbar-fixed-top">
         {# Navigation #}


### PR DESCRIPTION
Fixes #327 

Problem: is-hoverable are not working on touch devices, since there is no hover.
If touch device detected (https://stackoverflow.com/questions/56324813/how-to-detect-touch-device-in-2019) deletes all hovers from dropdown and replaces them with setting `is-active` on click