### PR TITLE
Fix wiki image alignment with Bulma styling

### DIFF
--- a/templates/wiki/base_site.html
+++ b/templates/wiki/base_site.html
@@ -36,6 +36,15 @@
       .wiki-messages {
         margin-bottom: 1rem;
       }
+      /* Image alignment styles */
+      .content figure.is-pulled-right {
+        margin-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content figure.is-pulled-left {
+        margin-right: 1.5rem;
+        margin-bottom: 1rem;
+      }
         </style>
         {% render_block "css" %}
     </head>

--- a/templates/wiki/plugins/images/render.html
+++ b/templates/wiki/plugins/images/render.html
@@ -1,0 +1,28 @@
+{% load wiki_thumbnails i18n %}
+{% comment %}
+  This template is used for the markdown extension that renders images and captions.
+  Customized for Bulma CSS framework (using is-pulled-* instead of float-*).
+
+  NB! Watch out for line breaks, markdown might add <br />s and <p>s.
+{% endcomment %}
+{% with image.current_revision.imagerevision as revision %}
+    {% spaceless %}
+        <figure class="image{% if align %} is-pulled-{{ align }}{% endif %}"
+                {% if width %}style="width: {{ width }}px;"{% endif %}>
+            <a href="{{ revision.image.url }}">
+                {% if size %}
+                    {% thumbnail revision.image size upscale=False as thumb %}
+                        <img src="{{ thumb.url }}" alt="{{ revision.get_filename }}" />
+                    {% empty %}
+                        <div class="has-text-grey-light">
+                            <em>{% trans "Image not found" %}</em>
+                        </div>
+                    {% endthumbnail %}
+                {% else %}
+                    <img src="{{ revision.image.url }}" alt="{{ revision.get_filename }}" />
+                {% endif %}
+            </a>
+            <figcaption class="has-text-centered has-text-grey">{{ caption|safe }}</figcaption>
+        </figure>
+    {% endspaceless %}
+{% endwith %}


### PR DESCRIPTION
This PR makes the following changes:

- Add custom templates/wiki/plugins/images/render.html to override
  django-wiki's default template, replacing Bootstrap's float-* classes
  with Bulma's is-pulled-* classes for left/right image alignment
- Add CSS in templates/wiki/base_site.html for proper margin spacing
  around aligned images so text wraps nicely

Django-wiki's default image template uses Bootstrap's float-left and
float-right classes which don't exist in Bulma. Images were being
aligned in the markdown but the CSS classes had no effect. Now uses
Bulma's is-pulled-left and is-pulled-right with appropriate margins.