### PR TITLE
Fix UnorderedObjectListWarning in reading list API

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -556,9 +556,13 @@ class ReadingListViewSet(
 
     def get_queryset(self):
         """Filter reading lists based on user permissions and visibility rules."""
-        queryset = ReadingList.objects.select_related("user").annotate(
-            average_rating=Avg("ratings__rating"),
-            rating_count=Count("ratings", distinct=True),
+        queryset = (
+            ReadingList.objects.select_related("user")
+            .annotate(
+                average_rating=Avg("ratings__rating"),
+                rating_count=Count("ratings", distinct=True),
+            )
+            .order_by("name", "attribution_source", "user")
         )
 
         # Unauthenticated users - only public lists


### PR DESCRIPTION
This PR quietes a warning in the reading list API, by adding explicit ordering to ReadingListViewSet queryset to prevent pagination warnings. The .annotate() call was overriding the model's default ordering, causing Django Rest Framework to warn about inconsistent pagination results.