### PR TITLE
Add datetime support to collection form date_read field

### DIFF
--- a/user_collection/forms.py
+++ b/user_collection/forms.py
@@ -67,10 +67,12 @@ class CollectionItemForm(forms.ModelForm):
                     "rows": 4,
                 }
             ),
-            "date_read": forms.DateInput(
+            "date_read": forms.DateTimeInput(
+                format="%Y-%m-%d %H:%M",
                 attrs={
-                    "type": "date",
+                    "type": "text",
                     "data-bulma-calendar": "on",
+                    "data-type": "datetime",
                 }
             ),
         }

--- a/user_collection/templates/user_collection/collection_form.html
+++ b/user_collection/templates/user_collection/collection_form.html
@@ -98,20 +98,30 @@
 document.addEventListener('DOMContentLoaded', function() {
     'use strict';
 
-    // Initialize bulma-calendar for date inputs
-    var dateInputs = document.querySelectorAll('input[data-bulma-calendar="on"]');
-    dateInputs.forEach(function(input) {
-        bulmaCalendar.attach(input, {
-            type: 'date',
+    // Initialize bulma-calendar for date and datetime inputs
+    var calendarInputs = document.querySelectorAll('input[data-bulma-calendar="on"]');
+
+    calendarInputs.forEach(function(input) {
+        var dataType = input.getAttribute('data-type');
+        var isDateTime = dataType === 'datetime';
+
+        var config = {
+            type: isDateTime ? 'datetime' : 'date',
             dateFormat: 'yyyy-MM-dd',
+            timeFormat: 'HH:mm',
             displayMode: 'default',
             showHeader: true,
-            closeOnSelect: true,
+            closeOnSelect: !isDateTime,
             clearButton: false,
             todayButton: true,
             showFooter: true,
-            weekStart: 0
-        });
+            weekStart: 0,
+            showClearButton: false,
+            showTodayButton: true,
+            closeOnOverlayClick: true
+        };
+
+        bulmaCalendar.attach(input, config);
     });
 });
     </script>


### PR DESCRIPTION
This PR changes the user_collection form to use a datetime widget isntead of a date widget

- Change date_read widget from DateInput to DateTimeInput in CollectionItemForm
- Add format parameter ("%Y-%m-%d %H:%M") to properly display existing datetime values
- Update form widget to use type="text" with data-type="datetime" for bulma-calendar compatibility
- Enhance collection_form.html JavaScript to detect and configure datetime vs date fields separately
- Configure bulma-calendar with timeFormat: 'HH:mm' for datetime fields
- Set closeOnSelect: false for datetime fields to allow time adjustment via +/- buttons
- Keep date-only fields (purchase_date) with original date picker behavior

The date_read field now supports full datetime selection with hour/minute adjustment
using bulma-calendar's +/- buttons and validate button workflow.