### PR TITLE
Add support for conditional requests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,7 @@ wiki = "*"
 django-htmx = "*"
 django-htmx-autocomplete = "*"
 django = "*"
+django-rest-framework-condition = "*"
 
 [dev-packages]
 django-debug-toolbar = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "55157fda47fc482a9ecf4ff168f40b1609d48eeac776c04ccab50dae0796e165"
+            "sha256": "1268e2ab1f844c1aa9e8b96de7cf873131e7eec993455659eebb7bf775f074b1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -162,6 +162,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.4.2"
+        },
+        "django-rest-framework-condition": {
+            "hashes": [
+                "sha256:04c90e454a0370d974d5d79eb7aa7e906da32eababe3a65b2f4f77ae47629b7a",
+                "sha256:e8fb77602013270fd86597aa213142ac2d9f086ab366da56e113f38d632ee0f9"
+            ],
+            "index": "pypi",
+            "version": "==0.1.1"
         },
         "django-sekizai": {
             "hashes": [

--- a/api/views.py
+++ b/api/views.py
@@ -9,6 +9,7 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework_condition import last_modified
 
 from api.v1_0.serializers import (
     ArcListSerializer,
@@ -80,6 +81,27 @@ class ReadingListItemsPagination(PageNumberPagination):
     page_size = 50
 
 
+class ConditionalRetrieveModelMixin(mixins.RetrieveModelMixin):
+    def retrieve(self, request, *args, **kwargs):
+        retrieve = last_modified(last_modified_func=self._last_modified)(super().retrieve)
+
+        return retrieve(self, request, *args, **kwargs)
+
+    def get_object(self):
+        if not hasattr(self, "_cached_object"):
+            self._cached_object = super().get_object()
+
+        return self._cached_object
+
+    def _last_modified(self, *args, **kwargs):
+        obj = self.get_object()
+
+        if obj and getattr(obj, "modified", None):
+            return obj.modified
+
+        return None
+
+
 class UserTrackingMixin:
     """Mixin to automatically track user edits in create and update operations."""
 
@@ -116,7 +138,7 @@ class ArcViewSet(
     UserTrackingMixin,
     IssueListMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -147,7 +169,7 @@ class CharacterViewSet(
     UserTrackingMixin,
     IssueListMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -185,7 +207,7 @@ class CharacterViewSet(
 class CreatorViewSet(
     UserTrackingMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -235,7 +257,7 @@ class CreditViewset(
 class ImprintViewSet(
     UserTrackingMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -277,7 +299,7 @@ class ImprintViewSet(
 class IssueViewSet(
     UserTrackingMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -334,7 +356,7 @@ class IssueViewSet(
 class PublisherViewSet(
     UserTrackingMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -396,7 +418,7 @@ class SeriesViewSet(
     UserTrackingMixin,
     IssueListMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -465,7 +487,7 @@ class TeamViewSet(
     UserTrackingMixin,
     IssueListMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -503,7 +525,7 @@ class TeamViewSet(
 class UniverseViewSet(
     UserTrackingMixin,
     mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
@@ -537,7 +559,7 @@ class UniverseViewSet(
 
 
 class ReadingListViewSet(
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     viewsets.GenericViewSet,
 ):
@@ -627,7 +649,7 @@ class VariantViewset(
 
 
 class CollectionViewSet(
-    mixins.RetrieveModelMixin,
+    ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
     viewsets.GenericViewSet,
 ):

--- a/tests/comicsdb/test_api_conditional_requests.py
+++ b/tests/comicsdb/test_api_conditional_requests.py
@@ -1,0 +1,156 @@
+from django.urls import reverse
+from rest_framework import status
+
+
+def test_arc_returns_last_modified_header(api_client_with_credentials, wwh_arc):
+    resp = api_client_with_credentials.get(
+        reverse("api:arc-detail", kwargs={"pk": wwh_arc.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert "Last-Modified" in resp
+
+
+def test_arc_conditional_request_returns_304(api_client_with_credentials, wwh_arc):
+    resp = api_client_with_credentials.get(
+        reverse("api:arc-detail", kwargs={"pk": wwh_arc.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:arc-detail", kwargs={"pk": wwh_arc.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_character_conditional_request_returns_304(api_client_with_credentials, superman):
+    resp = api_client_with_credentials.get(
+        reverse("api:character-detail", kwargs={"pk": superman.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:character-detail", kwargs={"pk": superman.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_creator_conditional_request_returns_304(api_client_with_credentials, john_byrne):
+    resp = api_client_with_credentials.get(
+        reverse("api:creator-detail", kwargs={"pk": john_byrne.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:creator-detail", kwargs={"pk": john_byrne.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_issue_conditional_request_returns_304(api_client_with_credentials, basic_issue):
+    resp = api_client_with_credentials.get(
+        reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:issue-detail", kwargs={"pk": basic_issue.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_publisher_conditional_request_returns_304(api_client_with_credentials, dc_comics):
+    resp = api_client_with_credentials.get(
+        reverse("api:publisher-detail", kwargs={"pk": dc_comics.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:publisher-detail", kwargs={"pk": dc_comics.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_series_conditional_request_returns_304(api_client_with_credentials, fc_series):
+    resp = api_client_with_credentials.get(
+        reverse("api:series-detail", kwargs={"pk": fc_series.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:series-detail", kwargs={"pk": fc_series.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_team_conditional_request_returns_304(api_client_with_credentials, teen_titans):
+    resp = api_client_with_credentials.get(
+        reverse("api:team-detail", kwargs={"pk": teen_titans.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:team-detail", kwargs={"pk": teen_titans.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_universe_conditional_request_returns_304(
+    api_client_with_credentials, earth_2_universe
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:universe-detail", kwargs={"pk": earth_2_universe.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:universe-detail", kwargs={"pk": earth_2_universe.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_imprint_conditional_request_returns_304(
+    api_client_with_credentials, vertigo_imprint
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:imprint-detail", kwargs={"pk": vertigo_imprint.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:imprint-detail", kwargs={"pk": vertigo_imprint.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_conditional_request_with_old_date_returns_200(
+    api_client_with_credentials, wwh_arc
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:arc-detail", kwargs={"pk": wwh_arc.pk}),
+        HTTP_IF_MODIFIED_SINCE="Wed, 01 Jan 2020 00:00:00 GMT",
+    )
+    assert resp.status_code == status.HTTP_200_OK
+
+
+def test_list_endpoint_does_not_return_304(api_client_with_credentials, wwh_arc, fc_arc):
+    resp = api_client_with_credentials.get(reverse("api:arc-list"))
+    assert resp.status_code == status.HTTP_200_OK
+    assert "Last-Modified" not in resp


### PR DESCRIPTION
In [go-metron](https://github.com/jyggen/go-metron) I use [heuristic caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#heuristic_caching) which caches the data and reuses it for 10% of the time between the request time and the `modified` property of the resource (e.g. has the resource not changed for 100 days it'll be cached for 10 days).

This is working great, but I'd like to improve it further. Currently, when a cached response expires, I make a call to the endpoint and cache the new response instead. However, more often than not, the fresh response is identical to the cached one, but there's no way for me to know that without first downloading and parsing the response body again. If there was a way, I could simply re-cache the response I already have cached and, through that, reduce the amount of data downloaded from Metron's API even further. Everyone would win!

In an attempt to solve that, this PR hooks up [Django's native Conditional View Processing](https://docs.djangoproject.com/en/5.2/topics/conditional-view-processing/) through the [django-rest-framework-condition](https://github.com/jozo/django-rest-framework-condition) 3rd-party package.  This is done by extending `RetrieveModelMixin` with a custom class with two overridden methods and one custom one:
- `retrieve`: wraps the parent's `retrieve` function with the `last_modified` decorator
- `_last_modified`: fetches and returns when the resource was last modified, used by the `last_modified` decorator
- `get_object`: overridden with a cache so our call to `to_object` in `_last_modified` don't cause additional SQL queries

<img width="526" height="359" alt="image" src="https://github.com/user-attachments/assets/ce48b5fa-1c91-4273-a5a7-f39ea4e60d4a" />

So, instead of downloading the entire response of a resource every time my cache goes stale, I can now call Metron with `If-Modified-Since: <date>`, with `<date>` being the `Last-Modified` header from the response in my cache. If the data hasn't changed since I first cached it, Metron will return `304 Not Modified` with an empty body, which means I can extend the TTL of the data in my cache and re-use that instead. Nice!

One caveat worth mentioning is that [django-rest-framework-condition](https://github.com/jozo/django-rest-framework-condition) hasn't been updated for quite some time, but it's 36 LoC that wraps Django's own decorators, so it should be a relatively low risk. 