### PR TITLE
Show read count badge in reading history for multiply-read issues

### DIFF
--- a/user_collection/templates/user_collection/reading_history.html
+++ b/user_collection/templates/user_collection/reading_history.html
@@ -61,7 +61,7 @@
                             {% for item in day_group.list %}
                                 <div class="column is-half-mobile is-one-third-tablet is-one-quarter-desktop is-one-fifth-widescreen">
                                     <div class="card">
-                                        <div class="card-image">
+                                        <div class="card-image" style="position: relative;">
                                             <figure class="image is-2by3">
                                                 <a href="{% url 'issue:detail' item.issue.slug %}">
                                                     {% if item.issue.image %}
@@ -75,6 +75,16 @@
                                                     {% endif %}
                                                 </a>
                                             </figure>
+                                            {% if item.read_count > 1 %}
+                                                <span class="tag is-info"
+                                                      style="position: absolute;
+                                                             top: 0.5rem;
+                                                             right: 0.5rem"
+                                                      title="Read {{ item.read_count }} times">
+                                                    <span class="icon is-small"><i class="fas fa-book-reader"></i></span>
+                                                    <span>&times;{{ item.read_count }}</span>
+                                                </span>
+                                            {% endif %}
                                         </div>
                                         <div class="card-content p-3">
                                             <p class="mb-2">

--- a/user_collection/views.py
+++ b/user_collection/views.py
@@ -521,6 +521,7 @@ class ReadingHistoryListView(LoginRequiredMixin, ListView):
                 "issue__series__publisher",
                 "issue__series__imprint",
             )
+            .annotate(read_count=Count("read_dates"))
             .order_by("-date_read", "-modified")
         )
 


### PR DESCRIPTION
This PR shows read count badge in reading history for multiply-read issues

Annotate ReadingHistoryListView queryset with read_dates count and display a badge overlay on the cover image when an issue has been read more than once.