### PR TITLE
Add reading history charts to Collection Statistics page

### DIFF
--- a/user_collection/templates/user_collection/collection_stats.html
+++ b/user_collection/templates/user_collection/collection_stats.html
@@ -108,6 +108,19 @@
                     </div>
                 </div>
             </div>
+            {# Reading History Charts #}
+            <div class="columns">
+                <div class="column is-half">
+                    <div class="box">
+                        <div class="content">{{ reading_daily_chart }}</div>
+                    </div>
+                </div>
+                <div class="column is-half">
+                    <div class="box">
+                        <div class="content">{{ reading_monthly_chart }}</div>
+                    </div>
+                </div>
+            </div>
             <div class="columns">
                 <div class="column is-half">
                     <div class="box">


### PR DESCRIPTION
This PR adds reading history charts to Collection Statistics page

Adds daily (last 30 days) and monthly (last 12 months) column charts to CollectionStatsView showing the user's reading activity over time. The daily chart displays all dates in the range, including days with no reading activity.