### PR TITLE
Improve API endpoint query performance

### DIFF
--- a/api/v1_0/serializers/series.py
+++ b/api/v1_0/serializers/series.py
@@ -8,7 +8,7 @@ from comicsdb.models import Series, SeriesType
 
 class SeriesListSerializer(serializers.ModelSerializer):
     series = serializers.CharField(source="__str__")
-    issue_count = serializers.ReadOnlyField()
+    issue_count = serializers.IntegerField(source="num_issues", read_only=True)
 
     class Meta:
         model = Series
@@ -96,6 +96,6 @@ class SeriesReadSerializer(SeriesSerializer):
     imprint = BasicImprintSerializer(read_only=True)
     series_type = SeriesTypeSerializer(read_only=True)
     status = serializers.CharField(source="get_status_display", read_only=True)
-    issue_count = serializers.ReadOnlyField()
+    issue_count = serializers.IntegerField(source="num_issues", read_only=True)
     associated = AssociatedSeriesSerializer(many=True, read_only=True)
     genres = GenreSerializer(many=True, read_only=True)

--- a/tests/comicsdb/test_api_series.py
+++ b/tests/comicsdb/test_api_series.py
@@ -3,7 +3,7 @@ from functools import reduce
 from urllib.parse import quote_plus
 
 import pytest
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.urls import reverse
 from rest_framework import status
 
@@ -106,7 +106,7 @@ def test_series_search(api_client_with_credentials, bat_sups_series, fc_series):
     resp = api_client_with_credentials.get(f"/api/series/?name={quote_plus(search_term)}")
     expected = Series.objects.filter(
         reduce(operator.and_, (Q(name__icontains=q) for q in search_term.split()))
-    )
+    ).annotate(num_issues=Count("issues", distinct=True))
     serializer = SeriesListSerializer(expected, many=True)
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["results"] == serializer.data


### PR DESCRIPTION
This PR Improves API endpoint query performance

- IssueViewSet: override get_queryset() to apply lightweight select_related only for list action, deferring the full prefetch of credits, arcs, characters, teams, universes, variants, and reprints to retrieve only
- SeriesViewSet: annotate num_issues via COUNT aggregate to replace N+1 per-instance issue_count property calls on list/retrieve; fix get_issue_queryset() to add select_related("series", "series__series_type") so IssueListSerializer doesn't N+1
- PublisherViewSet: remove unused prefetch_related("series") from base queryset; replace prefetch_related("issues") in series_list with COUNT annotation consumed by SeriesListSerializer
- ImprintViewSet: remove unused prefetch_related("series", "series__series_type") from base queryset
- CollectionViewSet.stats(): replace 6 separate DB queries with a single aggregate() call using conditional Count expressions
- SeriesListSerializer/SeriesReadSerializer: read issue_count from num_issues annotation instead of calling the model @property