### PR TITLE
Optimize various database queries

### DIFF
--- a/api/v1_0/serializers/series.py
+++ b/api/v1_0/serializers/series.py
@@ -32,6 +32,7 @@ class AssociatedSeriesSerializer(serializers.ModelSerializer):
 class SeriesSerializer(serializers.ModelSerializer):
     resource_url = serializers.SerializerMethodField("get_resource_url")
     status = serializers.ChoiceField(choices=Series.Status.choices)
+    issue_count = serializers.IntegerField(source="num_issues", read_only=True)
 
     def get_resource_url(self, obj: Series) -> str:
         return self.context["request"].build_absolute_uri(obj.get_absolute_url())

--- a/api/views.py
+++ b/api/views.py
@@ -315,13 +315,13 @@ class IssueViewSet(
     ImageHash. https://github.com/JohannesBuchner/imagehash
     """
 
-    queryset = Issue.objects.all()
+    queryset = Issue.objects.select_related("series", "series__series_type")
     filterset_class = IssueFilter
     parser_classes = (MultiPartParser, FormParser)
 
     def get_queryset(self):
         if self.action == "list":
-            return Issue.objects.select_related("series", "series__series_type")
+            return super().get_queryset()
         return Issue.objects.select_related(
             "series",
             "series__series_type",
@@ -450,18 +450,12 @@ class SeriesViewSet(
     filterset_class = SeriesFilter
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = super().get_queryset().annotate(num_issues=Count("issues", distinct=True))
         match self.action:
             case "list":
-                queryset = queryset.annotate(num_issues=Count("issues", distinct=True)).order_by(
-                    "sort_name", "year_began"
-                )
+                queryset = queryset.order_by("sort_name", "year_began")
             case "retrieve":
-                queryset = (
-                    queryset.select_related("imprint")
-                    .prefetch_related("genres", "associated")
-                    .annotate(num_issues=Count("issues", distinct=True))
-                )
+                queryset = queryset.select_related("imprint").prefetch_related("genres", "associated")
         return queryset
 
     def get_serializer_class(self):
@@ -489,6 +483,10 @@ class SeriesViewSet(
         return obj.issues.select_related("series", "series__series_type").order_by(
             "cover_date", "series", "number"
         )
+
+    def perform_create(self, serializer):
+        instance = serializer.save()
+        instance.num_issues = 0
 
 
 class SeriesTypeViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/comicsdb/models/arc.py
+++ b/comicsdb/models/arc.py
@@ -39,10 +39,6 @@ class Arc(CommonInfo):
                 this.image.delete(save=False)
         return super().save(*args, **kwargs)
 
-    @property
-    def issue_count(self) -> int:
-        return self.issues.count()
-
     def get_absolute_url(self):
         return reverse("arc:detail", args=[self.slug])
 

--- a/comicsdb/models/character.py
+++ b/comicsdb/models/character.py
@@ -51,10 +51,6 @@ class Character(CommonInfo):
         return reverse("character:detail", args=[self.slug])
 
     @property
-    def issue_count(self) -> int:
-        return self.issues.count()
-
-    @property
     def first_appearance(self):
         return self.issues.order_by("cover_date").first()
 

--- a/comicsdb/models/imprint.py
+++ b/comicsdb/models/imprint.py
@@ -46,10 +46,6 @@ class Imprint(CommonInfo):
         return reverse("imprint:detail", args=[self.slug])
 
     @property
-    def series_count(self):
-        return self.series.all().count()
-
-    @property
     def wikipedia(self):
         return self.attribution.filter(source=Attribution.Source.WIKIPEDIA)
 

--- a/comicsdb/models/issue.py
+++ b/comicsdb/models/issue.py
@@ -114,7 +114,7 @@ class Issue(CommonInfo):
         return super().save(*args, **kwargs)
 
     def __str__(self) -> str:
-        match self.series.series_type.id:
+        match self.series.series_type_id:
             case 12:
                 return f"{self.series} Chapter #{self.number}"
             case _:

--- a/comicsdb/models/publisher.py
+++ b/comicsdb/models/publisher.py
@@ -46,10 +46,6 @@ class Publisher(CommonInfo):
         return reverse("publisher:detail", args=[self.slug])
 
     @property
-    def series_count(self) -> int:
-        return self.series.count()
-
-    @property
     def wikipedia(self):
         return self.attribution.filter(source=Attribution.Source.WIKIPEDIA)
 

--- a/comicsdb/models/series.py
+++ b/comicsdb/models/series.py
@@ -69,7 +69,7 @@ class Series(CommonInfo):
         return reverse("series:detail", args=[self.slug])
 
     def __str__(self) -> str:
-        match self.series_type.id:
+        match self.series_type_id:
             case 12:
                 return f"{self.name} ({self.year_began}) Digital"
             case 10:
@@ -86,10 +86,6 @@ class Series(CommonInfo):
             return self.issues.first().image
         except AttributeError:
             return None
-
-    @property
-    def issue_count(self) -> int:
-        return self.issues.count()
 
     class Meta:
         indexes = [

--- a/comicsdb/models/team.py
+++ b/comicsdb/models/team.py
@@ -47,10 +47,6 @@ class Team(CommonInfo):
         return reverse("team:detail", args=[self.slug])
 
     @property
-    def issue_count(self) -> int:
-        return self.issues.count()
-
-    @property
     def wikipedia(self):
         return self.attribution.filter(source=Attribution.Source.WIKIPEDIA)
 

--- a/comicsdb/models/universe.py
+++ b/comicsdb/models/universe.py
@@ -46,10 +46,6 @@ class Universe(CommonInfo):
         return reverse("universe:detail", args=[self.slug])
 
     @property
-    def issue_count(self):
-        return self.issues.all().count()
-
-    @property
     def first_appearance(self):
         return self.issues.order_by("cover_date").all().first
 

--- a/comicsdb/views/arc.py
+++ b/comicsdb/views/arc.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.views.generic import DetailView, ListView
@@ -25,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 class ArcList(LoginRequiredMixin, ListView):
     model = Arc
     paginate_by = PAGINATE_BY
-    queryset = Arc.objects.prefetch_related("issues")
+    queryset = Arc.objects.annotate(issue_count=Count("issues"))
 
 
 class ArcIssueList(LoginRequiredMixin, ListView):

--- a/comicsdb/views/character.py
+++ b/comicsdb/views/character.py
@@ -39,7 +39,7 @@ class CharacterSeriesList(LoginRequiredMixin, ListView):
 class CharacterList(LoginRequiredMixin, ListView):
     model = Character
     paginate_by = PAGINATE_BY
-    queryset = Character.objects.prefetch_related("issues")
+    queryset = Character.objects.annotate(issue_count=Count("issues"))
 
 
 class CharacterIssueList(LoginRequiredMixin, ListView):

--- a/comicsdb/views/home.py
+++ b/comicsdb/views/home.py
@@ -25,7 +25,7 @@ class HomePageView(TemplateView):
         recently_edited = cache.get("recently_edited")
         if not recently_edited:
             recently_edited = (
-                Issue.objects.prefetch_related("series", "series__series_type")
+                Issue.objects.select_related("series", "series__series_type")
                 .order_by("-modified")
                 .all()[:12]
             )

--- a/comicsdb/views/imprint.py
+++ b/comicsdb/views/imprint.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
@@ -23,7 +24,7 @@ LOGGER = logging.getLogger(__name__)
 class ImprintList(LoginRequiredMixin, ListView):
     model = Imprint
     paginate_by = PAGINATE_BY
-    queryset = Imprint.objects.prefetch_related("series")
+    queryset = Imprint.objects.annotate(series_count=Count("series"))
 
 
 class ImprintSeriesList(LoginRequiredMixin, ListView):

--- a/comicsdb/views/publisher.py
+++ b/comicsdb/views/publisher.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.views.generic import DetailView, ListView
@@ -26,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 class PublisherList(LoginRequiredMixin, ListView):
     model = Publisher
     paginate_by = PAGINATE_BY
-    queryset = Publisher.objects.prefetch_related("series")
+    queryset = Publisher.objects.annotate(series_count=Count("series"))
 
 
 class PublisherSeriesList(LoginRequiredMixin, ListView):

--- a/comicsdb/views/series.py
+++ b/comicsdb/views/series.py
@@ -29,7 +29,7 @@ class SeriesList(LoginRequiredMixin, ListView):
     def get_queryset(self):
         queryset = Series.objects.select_related(
             "series_type", "publisher", "imprint"
-        ).prefetch_related("issues")
+        ).annotate(issue_count=Count("issues"))
         # Apply filters
         filtered = SeriesViewFilter(self.request.GET, queryset=queryset)
         return filtered.qs

--- a/comicsdb/views/team.py
+++ b/comicsdb/views/team.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.views.generic import DetailView, ListView
@@ -25,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 class TeamList(LoginRequiredMixin, ListView):
     model = Team
     paginate_by = PAGINATE_BY
-    queryset = Team.objects.prefetch_related("issues")
+    queryset = Team.objects.annotate(issue_count=Count("issues"))
 
 
 class TeamIssueList(LoginRequiredMixin, ListView):

--- a/comicsdb/views/universe.py
+++ b/comicsdb/views/universe.py
@@ -40,7 +40,7 @@ class UniverseSeriesList(LoginRequiredMixin, ListView):
 class UniverseList(LoginRequiredMixin, ListView):
     model = Universe
     paginate_by = PAGINATE_BY
-    queryset = Universe.objects.prefetch_related("issues")
+    queryset = Universe.objects.annotate(issue_count=Count("issues"))
 
 
 class UniverseIssueList(LoginRequiredMixin, ListView):


### PR DESCRIPTION
This PR addresses several N+1 query issues I noticed while clicking around in Metron locally, as well as a couple of other optimizations.

In short:
- I changed `series_type.id` to `series_type_id` in `Issue.__str__` and `Series.__str__` as this caused one query to get the series type object for each issue/series that was being "stringified", only to retrieve the ID (which we already have access to). 
- I replaced `prefetch_related` + `*_count` property with an `annotate(Count(...))`. The `prefetch_related` loads _all_ related issues/series into memory only to then count them, causing quite a lot of memory usage for relationships with a lot of related issues/series. Now it's a simple `GROUP BY` query instead.
- I changed `prefetch_related` to `select_related` on the home view since both `series` and `series__series_type` and has-one relationships, so now that data is joined into the main query instead of being fetched in separate queries.
- Tweaked `SeriesViewSet.get_queryset` so all actions get `num_issues` from the database without extra queries. `create` responses requires some extra handling to avoid it being `null`, thus the `perform_create` was added to set `num_issues` to 0 (a newly created series never has any issues). 