### PR TITLE
Avoid unnecessary series type queries

### DIFF
--- a/comicsdb/models/issue.py
+++ b/comicsdb/models/issue.py
@@ -114,7 +114,7 @@ class Issue(CommonInfo):
         return super().save(*args, **kwargs)
 
     def __str__(self) -> str:
-        match self.series.series_type.id:
+        match self.series.series_type_id:
             case 12:
                 return f"{self.series} Chapter #{self.number}"
             case _:

--- a/comicsdb/models/series.py
+++ b/comicsdb/models/series.py
@@ -69,7 +69,7 @@ class Series(CommonInfo):
         return reverse("series:detail", args=[self.slug])
 
     def __str__(self) -> str:
-        match self.series_type.id:
+        match self.series_type_id:
             case 12:
                 return f"{self.name} ({self.year_began}) Digital"
             case 10:


### PR DESCRIPTION
The access to `series_type.id` causes the related series type to be queried every time an issue or series is turned into its string representation, which can results in dozens of additional queries on some views. Since only `id` is accessed, `__str__` can be optimized into using `series_type_id` instead, which avoids the additional query altogether.