### PR TITLE
Add conditional request support for reading list items

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1689,9 +1689,13 @@ Conditional requests are supported on the following endpoints:
 - `GET /api/series/{id}/issue_list/`
 - `GET /api/team/{id}/issue_list/`
 
+**Reading list items endpoint:**
+
+- `GET /api/reading_list/{id}/items/`
+
 **Note:** General list endpoints (`GET /api/{resource}/`) do not support conditional requests.
 
-**Tip:** Since a parent object's `modified` timestamp is updated whenever its issues change (added, edited, or removed), you can use conditional requests on the parent detail endpoint (e.g. `GET /api/arc/{id}/`) to detect whether the issue list has changed, without needing to call the `issue_list/` endpoint at all.
+**Tip:** Since a parent object's `modified` timestamp is updated whenever its issues change (added, edited, or removed), you can use conditional requests on the parent detail endpoint (e.g. `GET /api/arc/{id}/`) to detect whether the issue list has changed, without needing to call the `issue_list/` endpoint at all. The same applies to reading lists: the `GET /api/reading_list/{id}/` detail endpoint is updated whenever an item is added to or removed from the list, so you can use it to detect changes without calling the `items/` endpoint.
 
 ### Example
 

--- a/reading_lists/apps.py
+++ b/reading_lists/apps.py
@@ -1,6 +1,22 @@
 from django.apps import AppConfig
+from django.db.models.signals import post_delete, post_save
+
+from reading_lists.signals import update_reading_list_modified_on_item_change
 
 
 class ReadingListsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "reading_lists"
+
+    def ready(self):
+        reading_list_item = self.get_model("ReadingListItem")
+        post_save.connect(
+            update_reading_list_modified_on_item_change,
+            sender=reading_list_item,
+            dispatch_uid="post_save_reading_list_item_modified",
+        )
+        post_delete.connect(
+            update_reading_list_modified_on_item_change,
+            sender=reading_list_item,
+            dispatch_uid="post_delete_reading_list_item_modified",
+        )

--- a/reading_lists/signals.py
+++ b/reading_lists/signals.py
@@ -1,0 +1,7 @@
+from django.utils import timezone
+
+
+def update_reading_list_modified_on_item_change(sender, instance, **kwargs):
+    from reading_lists.models import ReadingList  # noqa: PLC0415
+
+    ReadingList.objects.filter(pk=instance.reading_list_id).update(modified=timezone.now())

--- a/tests/reading_lists/test_api_reading_list.py
+++ b/tests/reading_lists/test_api_reading_list.py
@@ -279,3 +279,43 @@ def test_items_response_structure(api_client_with_credentials, reading_list_with
         # Check nested issue structure
         assert "id" in item["issue"]
         assert "series" in item["issue"]
+
+
+# Conditional Request Tests
+def test_reading_list_detail_returns_last_modified_header(
+    api_client_with_credentials, public_reading_list
+):
+    """Test that reading list detail response includes Last-Modified header."""
+    resp = api_client_with_credentials.get(
+        reverse("api:reading_list-detail", kwargs={"pk": public_reading_list.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert "Last-Modified" in resp
+
+
+def test_reading_list_detail_conditional_request_returns_304(
+    api_client_with_credentials, public_reading_list
+):
+    """Test that reading list detail returns 304 when If-Modified-Since matches."""
+    resp = api_client_with_credentials.get(
+        reverse("api:reading_list-detail", kwargs={"pk": public_reading_list.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    last_modified = resp["Last-Modified"]
+
+    resp = api_client_with_credentials.get(
+        reverse("api:reading_list-detail", kwargs={"pk": public_reading_list.pk}),
+        HTTP_IF_MODIFIED_SINCE=last_modified,
+    )
+    assert resp.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_reading_list_detail_conditional_request_returns_200_for_older_date(
+    api_client_with_credentials, public_reading_list
+):
+    """Test that reading list detail returns 200 when If-Modified-Since is older."""
+    resp = api_client_with_credentials.get(
+        reverse("api:reading_list-detail", kwargs={"pk": public_reading_list.pk}),
+        HTTP_IF_MODIFIED_SINCE="Sat, 01 Jan 2000 00:00:00 GMT",
+    )
+    assert resp.status_code == status.HTTP_200_OK

--- a/tests/reading_lists/test_signals.py
+++ b/tests/reading_lists/test_signals.py
@@ -1,0 +1,36 @@
+"""Tests for reading_lists signals."""
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from reading_lists.models import ReadingList, ReadingListItem
+from reading_lists.signals import update_reading_list_modified_on_item_change
+
+
+def test_reading_list_item_save_updates_reading_list_modified(
+    reading_list_with_issues, reading_list_item
+):
+    """Creating or updating a ReadingListItem bumps the parent ReadingList.modified."""
+    past = timezone.now() - timedelta(days=1)
+    ReadingList.objects.filter(pk=reading_list_with_issues.pk).update(modified=past)
+    reading_list_with_issues.refresh_from_db()
+    old_modified = reading_list_with_issues.modified
+
+    update_reading_list_modified_on_item_change(sender=ReadingListItem, instance=reading_list_item)
+    reading_list_with_issues.refresh_from_db()
+    assert reading_list_with_issues.modified > old_modified
+
+
+def test_reading_list_item_delete_updates_reading_list_modified(
+    reading_list_with_issues, reading_list_item
+):
+    """Deleting a ReadingListItem bumps the parent ReadingList.modified."""
+    past = timezone.now() - timedelta(days=1)
+    ReadingList.objects.filter(pk=reading_list_with_issues.pk).update(modified=past)
+    reading_list_with_issues.refresh_from_db()
+    old_modified = reading_list_with_issues.modified
+
+    update_reading_list_modified_on_item_change(sender=ReadingListItem, instance=reading_list_item)
+    reading_list_with_issues.refresh_from_db()
+    assert reading_list_with_issues.modified > old_modified


### PR DESCRIPTION
This PR adds conditional request support for reading list items

- Add a post_save/post_delete signal on ReadingListItem that bumps the parent ReadingList.modified whenever an item is added or removed, keeping the conditional request timestamp accurate
- Document the behaviour in the API README, noting that clients can use the detail endpoint to detect item changes without calling /items/
- Add tests for the signal and for the conditional request behaviour