### PR TITLE
Add daily API rate limit usage display to user profile

### DIFF
--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -1,8 +1,12 @@
+import time
+
 import pytest
+from django.core.cache import cache
 from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
 from users.forms import CustomUserChangeForm
+from users.views import SUSTAINED_DURATION, SUSTAINED_LIMIT, get_rate_limit_usage
 
 HTML_REDIRECT_CODE = 301
 HTML_OK_CODE = 200
@@ -120,3 +124,67 @@ def test_form_invalid(db):
         }
     )
     assert form.is_valid() is False
+
+
+# --- get_rate_limit_usage tests ---
+
+
+def test_rate_limit_usage_no_history(create_user):
+    user = create_user()
+    cache.delete(f"throttle_sustained_{user.pk}")
+    result = get_rate_limit_usage(user)
+    assert result["used"] == 0
+    assert result["remaining"] == SUSTAINED_LIMIT
+    assert result["limit"] == SUSTAINED_LIMIT
+    assert result["percent_used"] == 0.0
+
+
+def test_rate_limit_usage_with_history(create_user):
+    user = create_user()
+    now = time.time()
+    # Simulate 10 recent requests
+    cache.set(f"throttle_sustained_{user.pk}", [now - i for i in range(10)])
+    result = get_rate_limit_usage(user)
+    assert result["used"] == 10
+    assert result["remaining"] == SUSTAINED_LIMIT - 10
+    cache.delete(f"throttle_sustained_{user.pk}")
+
+
+def test_rate_limit_usage_filters_old_timestamps(create_user):
+    user = create_user()
+    now = time.time()
+    recent = [now - 100, now - 200]
+    old = [now - SUSTAINED_DURATION - 1, now - SUSTAINED_DURATION - 3600]
+    cache.set(f"throttle_sustained_{user.pk}", recent + old)
+    result = get_rate_limit_usage(user)
+    assert result["used"] == 2
+    cache.delete(f"throttle_sustained_{user.pk}")
+
+
+def test_rate_limit_percent_used(create_user):
+    user = create_user()
+    now = time.time()
+    used = 500
+    cache.set(f"throttle_sustained_{user.pk}", [now - i for i in range(used)])
+    result = get_rate_limit_usage(user)
+    assert result["percent_used"] == round(used / SUSTAINED_LIMIT * 100, 1)
+    cache.delete(f"throttle_sustained_{user.pk}")
+
+
+# --- Profile view rate_limit context tests ---
+
+
+def test_profile_view_includes_rate_limit_for_own_profile(auto_login_user):
+    client, user = auto_login_user()
+    resp = client.get(reverse("user-detail", kwargs={"username": user.username}))
+    assert resp.status_code == HTML_OK_CODE
+    assert "rate_limit" in resp.context
+    assert resp.context["rate_limit"]["limit"] == SUSTAINED_LIMIT
+
+
+def test_profile_view_excludes_rate_limit_for_other_profile(auto_login_user, create_user):
+    client, _ = auto_login_user()
+    other = create_user()
+    resp = client.get(reverse("user-detail", kwargs={"username": other.username}))
+    assert resp.status_code == HTML_OK_CODE
+    assert "rate_limit" not in resp.context

--- a/users/templates/users/customuser_detail.html
+++ b/users/templates/users/customuser_detail.html
@@ -340,6 +340,24 @@
                                 <span class="tag is-warning is-light">Not Confirmed</span>
                             {% endif %}
                         </p>
+                        {% if rate_limit %}
+                            <div class="mt-4">
+                                <p class="mb-1">
+                                    <span class="icon" aria-hidden="true">
+                                        <i class="fas fa-tachometer-alt"></i>
+                                    </span>
+                                    <strong>Daily API Usage:</strong>
+                                    {{ rate_limit.used }} / {{ rate_limit.limit }}
+                                    <span class="has-text-grey is-size-7">({{ rate_limit.remaining }} remaining)</span>
+                                </p>
+                                <progress class="progress {% if rate_limit.percent_used >= 90 %}is-danger{% elif rate_limit.percent_used >= 70 %}is-warning{% else %}is-info{% endif %} is-small"
+                                          value="{{ rate_limit.used }}"
+                                          max="{{ rate_limit.limit }}"
+                                          title="{{ rate_limit.percent_used }}% used">
+                                    {{ rate_limit.percent_used }}%
+                                </progress>
+                            </div>
+                        {% endif %}
                         <div class="buttons mt-4">
                             <a class="button is-small is-fullwidth"
                                href="{% url 'change_profile' %}">

--- a/users/views.py
+++ b/users/views.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from django.contrib import messages
 from django.contrib.auth import login, update_session_auth_hash
@@ -6,13 +7,14 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import PasswordChangeView
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.cache import cache
 from django.core.mail import EmailMultiAlternatives
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse, reverse_lazy
 from django.utils.encoding import force_bytes, force_str
+from django.utils.html import format_html
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
-from django.utils.safestring import mark_safe
 from django.views.generic import DetailView, ListView
 
 # Import models for counting
@@ -64,11 +66,11 @@ def activate(request, uidb64, token):
     send_pushover(f"{user} activated their account on Metron.")
     logger.info("%s activated their account on Metron", user)
     # Add a message asking the user to star the repository.
-    msg = (
+    msg = format_html(
         "If you are planning on adding new information to the database, please refer to the "
         "<a href='/wiki/editing-guidelines/'>Editing Guidelines</a>."
     )
-    messages.success(request, mark_safe(msg))
+    messages.success(request, msg)
 
     return redirect("home")
 
@@ -143,6 +145,21 @@ def user_profile_redirect(request, pk):
 
 
 PAGINATE_BY = 28
+SUSTAINED_LIMIT = 5000
+SUSTAINED_DURATION = 86400  # 1 day in seconds
+
+
+def get_rate_limit_usage(user):
+    cache_key = f"throttle_sustained_{user.pk}"
+    history = cache.get(cache_key, [])
+    now = time.time()
+    used = sum(1 for ts in history if ts > now - SUSTAINED_DURATION)
+    return {
+        "limit": SUSTAINED_LIMIT,
+        "used": used,
+        "remaining": max(0, SUSTAINED_LIMIT - used),
+        "percent_used": round(used / SUSTAINED_LIMIT * 100, 1),
+    }
 
 
 class UserList(LoginRequiredMixin, ListView):
@@ -177,6 +194,10 @@ class UserProfile(LoginRequiredMixin, DetailView):
             "arcs": Arc.objects.filter(created_by=user).count(),
             "universes": Universe.objects.filter(created_by=user).count(),
         }
+
+        # Add daily API rate limit usage (only visible to the user themselves)
+        if user.pk == self.request.user.pk:
+            context["rate_limit"] = get_rate_limit_usage(user)
 
         # Add recent reading history (last 10 items)
         context["recent_reads"] = (


### PR DESCRIPTION
This PR adds daily API rate limit usage display to user profile

- Show the user's current daily API usage (requests used, remaining, and a color-coded progress bar) in the Account Settings section of their profile page. The section is only visible to the profile owner.
- The data is read directly from the DRF throttle cache (throttle_sustained_<pk>).
-  Add tests