### PR TITLE
Add Publisher Filter to Reading List View

### DIFF
--- a/comicsdb/filters/reading_list.py
+++ b/comicsdb/filters/reading_list.py
@@ -71,6 +71,13 @@ class ReadingListViewFilter(df.FilterSet):
     # Privacy filter
     is_private = df.BooleanFilter(label="Private")
 
+    # Publisher filter
+    publisher = df.CharFilter(
+        label="Publisher",
+        field_name="reading_list_items__issue__series__publisher__name",
+        lookup_expr="icontains",
+    )
+
     # Rating filter
     average_rating__gte = df.NumberFilter(
         field_name="average_rating",
@@ -84,6 +91,7 @@ class ReadingListViewFilter(df.FilterSet):
             "q",
             "name",
             "username",
+            "publisher",
             "attribution_source",
             "is_private",
             "average_rating__gte",

--- a/reading_lists/templates/reading_lists/partials/readinglist_filter.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_filter.html
@@ -82,6 +82,24 @@
                         </div>
                     </div>
                 </div>
+                {# Publisher Filter #}
+                <div class="column is-half">
+                    <div class="field">
+                        <label class="label" for="publisher">Publisher</label>
+                        <div class="control has-icons-left">
+                            <input class="input"
+                                   type="text"
+                                   id="publisher"
+                                   name="publisher"
+                                   value="{{ request.GET.publisher }}"
+                                   placeholder="e.g., Marvel"
+                                   aria-label="Filter by publisher">
+                            <span class="icon is-small is-left">
+                                <i class="fas fa-building"></i>
+                            </span>
+                        </div>
+                    </div>
+                </div>
                 {# Attribution Source Filter #}
                 <div class="column is-half">
                     <div class="field">

--- a/reading_lists/views.py
+++ b/reading_lists/views.py
@@ -87,7 +87,7 @@ class ReadingListListView(ListView):
 
         # Apply filters
         filtered = ReadingListViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs.order_by("name", "attribution_source", "user")
+        return filtered.qs.distinct().order_by("name", "attribution_source", "user")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/tests/reading_lists/test_views.py
+++ b/tests/reading_lists/test_views.py
@@ -67,6 +67,32 @@ class TestReadingListListView:
         assert resp.status_code == HTTP_200_OK
         assert len(resp.context["reading_lists"]) == 30  # paginate_by = 30
 
+    def test_filter_by_publisher(
+        self, client, public_reading_list, reading_list_with_issues, reading_list_publisher
+    ):
+        """Test filtering reading lists by publisher name."""
+        url = reverse("reading-list:list")
+        resp = client.get(url, {"publisher": reading_list_publisher.name})
+        assert resp.status_code == HTTP_200_OK
+        assert reading_list_with_issues in resp.context["reading_lists"]
+        # List with no issues has no publisher association
+        assert public_reading_list not in resp.context["reading_lists"]
+
+    def test_filter_by_publisher_no_results(self, client, reading_list_with_issues):
+        """Test that filtering by a non-existent publisher returns no results."""
+        url = reverse("reading-list:list")
+        resp = client.get(url, {"publisher": "Nonexistent Publisher"})
+        assert resp.status_code == HTTP_200_OK
+        assert len(resp.context["reading_lists"]) == 0
+
+    def test_filter_by_publisher_no_duplicates(self, client, reading_list_with_issues):
+        """Test that filtering by publisher does not return duplicate reading lists."""
+        url = reverse("reading-list:list")
+        resp = client.get(url, {"publisher": "Test Publisher"})
+        assert resp.status_code == HTTP_200_OK
+        reading_lists = list(resp.context["reading_lists"])
+        assert len(reading_lists) == len({rl.pk for rl in reading_lists})
+
 
 class TestSearchReadingListListView:
     """Tests for the SearchReadingListListView."""


### PR DESCRIPTION
This PR adds a publisher filter to reading list view

- Add a publisher filter to ReadingListViewFilter and ReadingListListView, allowing users to filter reading lists by publisher name via the Advanced Filters panel.
- Add a distinct() call to prevent duplicate results from the M2M traversal through reading list items.
- Add a Publisher text input field to the filter template and tests to cover the new functionality.