### PR TITLE
Fix SeriesViewSet PATCH method from overwriting existing imprint value

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -496,7 +496,11 @@ class SeriesViewSet(
         serializer_class = self.get_serializer_class()
         kwargs["context"] = self.get_serializer_context()
 
-        if "data" in kwargs and not kwargs["data"].get("imprint"):
+        if (
+            self.action != "partial_update"
+            and "data" in kwargs
+            and not kwargs["data"].get("imprint")
+        ):
             data = kwargs["data"].copy()
             data["imprint"] = None
             kwargs["data"] = data


### PR DESCRIPTION
This PR fixes a bug where the SeriesViewSet PATCH method was overwriting existing imprint value

The get_serializer() imprint-normalization logic fired on all write actions, including partial_update (PATCH). This caused any PATCH request that omitted the imprint field to silently set it to None, clearing the existing imprint. Add a guard to the normalization so it only runs on create and full update actions.