### PR TITLE
Include series ID in issue list response

### DIFF
--- a/api/v1_0/serializers/issue.py
+++ b/api/v1_0/serializers/issue.py
@@ -112,7 +112,7 @@ class IssueSeriesSerializer(serializers.ModelSerializer):
 class IssueListSeriesSerializer(serializers.ModelSerializer):
     class Meta:
         model = Series
-        fields = ("name", "volume", "year_began")
+        fields = ("id", "name", "volume", "year_began")
 
 
 class IssueListSerializer(serializers.ModelSerializer):

--- a/tests/comicsdb/test_api_issue.py
+++ b/tests/comicsdb/test_api_issue.py
@@ -88,6 +88,12 @@ def test_unauthorized_view_url(api_client, list_of_issues):
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
+def test_view_url_includes_series_id(api_client_with_credentials, list_of_issues, fc_series):
+    resp = api_client_with_credentials.get(reverse("api:issue-list"))
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["results"][0]["series"]["id"] == fc_series.id
+
+
 def test_get_valid_single_arc(api_client_with_credentials, issue_with_arc):
     resp = api_client_with_credentials.get(
         reverse("api:issue-detail", kwargs={"pk": issue_with_arc.pk})


### PR DESCRIPTION
The IssueListSeriesSerializer currently returns name, volume, and year_began but not the series id. This means API consumers who want to cache or link series data from search results have to make a separate request per result to get the series id (either fetching the full issue or searching for the series).

Adding id to the serializer fields fixes this with no extra queries since the series is already being serialized via select_related.