### PR TITLE
Fix autocomplete widget crash on empty string values

### DIFF
--- a/comicsdb/forms/creator.py
+++ b/comicsdb/forms/creator.py
@@ -1,10 +1,10 @@
-from autocomplete import widgets
 from django.forms import ClearableFileInput, DateInput, ModelForm
 
 from comicsdb.autocomplete import CreatorAutocomplete
+from comicsdb.forms.widgets import SafeAutocompleteWidget
 from comicsdb.models import Creator
 
-CreatorsWidget = widgets.AutocompleteWidget(
+CreatorsWidget = SafeAutocompleteWidget(
     ac_class=CreatorAutocomplete,
     attrs={"class": "input"},
     options={"multiselect": True},

--- a/comicsdb/forms/credits.py
+++ b/comicsdb/forms/credits.py
@@ -1,14 +1,14 @@
-from autocomplete import widgets
 from django.forms import ModelChoiceField, ModelForm, SelectMultiple, inlineformset_factory
 
 from comicsdb.autocomplete import CreatorAutocomplete
+from comicsdb.forms.widgets import SafeAutocompleteWidget
 from comicsdb.models import Creator, Credits, Issue
 
 
 class CreditsForm(ModelForm):
     creator = ModelChoiceField(
         queryset=Creator.objects.all(),
-        widget=widgets.AutocompleteWidget(
+        widget=SafeAutocompleteWidget(
             ac_class=CreatorAutocomplete,
             attrs={
                 "placeholder": "Autocomplete...",

--- a/comicsdb/forms/issue.py
+++ b/comicsdb/forms/issue.py
@@ -1,4 +1,3 @@
-from autocomplete import widgets
 from django.forms import (
     ClearableFileInput,
     DateInput,
@@ -16,25 +15,25 @@ from comicsdb.autocomplete import (
 )
 from comicsdb.forms.team import TeamsWidget
 from comicsdb.forms.universe import UniversesWidget
-from comicsdb.forms.widgets import BulmaMoneyWidget
+from comicsdb.forms.widgets import BulmaMoneyWidget, SafeAutocompleteWidget
 from comicsdb.models import Issue, Rating, Series
 
 MINIMUM_YEAR = 1900
 
 
-ArcsWidget = widgets.AutocompleteWidget(
+ArcsWidget = SafeAutocompleteWidget(
     ac_class=ArcAutocomplete,
     attrs={"class": "input"},
     options={"multiselect": True},
 )
 
-CharactersWidget = widgets.AutocompleteWidget(
+CharactersWidget = SafeAutocompleteWidget(
     ac_class=CharacterAutocomplete,
     attrs={"class": "input"},
     options={"multiselect": True},
 )
 
-IssuesWidget = widgets.AutocompleteWidget(
+IssuesWidget = SafeAutocompleteWidget(
     ac_class=IssueAutocomplete,
     attrs={"class": "input"},
     options={"multiselect": True},
@@ -44,7 +43,7 @@ IssuesWidget = widgets.AutocompleteWidget(
 class IssueForm(ModelForm):
     series = ModelChoiceField(
         queryset=Series.objects.all(),
-        widget=widgets.AutocompleteWidget(
+        widget=SafeAutocompleteWidget(
             ac_class=SeriesAutocomplete,
             attrs={
                 "placeholder": "Autocomplete...",

--- a/comicsdb/forms/publisher.py
+++ b/comicsdb/forms/publisher.py
@@ -1,10 +1,10 @@
-from autocomplete import widgets
 from django.forms import ClearableFileInput, ModelForm, ValidationError
 
 from comicsdb.autocomplete import PublisherAutocomplete
+from comicsdb.forms.widgets import SafeAutocompleteWidget
 from comicsdb.models import Publisher
 
-PublisherWidget = widgets.AutocompleteWidget(
+PublisherWidget = SafeAutocompleteWidget(
     ac_class=PublisherAutocomplete,
     attrs={"class": "input"},
 )

--- a/comicsdb/forms/series.py
+++ b/comicsdb/forms/series.py
@@ -1,7 +1,7 @@
-from autocomplete import widgets
 from django.forms import ModelChoiceField, ModelForm, ValidationError
 
 from comicsdb.autocomplete import ImprintAutocomplete, PublisherAutocomplete, SeriesAutocomplete
+from comicsdb.forms.widgets import SafeAutocompleteWidget
 from comicsdb.models import Imprint, Publisher, Series
 
 # Series_Type objects id's
@@ -10,12 +10,12 @@ OMNI = 15
 TPB = 10
 
 
-SeriesWidget = widgets.AutocompleteWidget(
+SeriesWidget = SafeAutocompleteWidget(
     ac_class=SeriesAutocomplete,
     attrs={"class": "input"},
 )
 
-MultiSeriesWidget = widgets.AutocompleteWidget(
+MultiSeriesWidget = SafeAutocompleteWidget(
     ac_class=SeriesAutocomplete,
     attrs={"class": "input"},
     options={"multiselect": True},
@@ -26,12 +26,12 @@ class SeriesForm(ModelForm):
     publisher = ModelChoiceField(
         queryset=Publisher.objects.all(),
         label="Publisher",
-        widget=widgets.AutocompleteWidget(ac_class=PublisherAutocomplete),
+        widget=SafeAutocompleteWidget(ac_class=PublisherAutocomplete),
     )
     imprint = ModelChoiceField(
         queryset=Imprint.objects.all(),
         label="Imprint",
-        widget=widgets.AutocompleteWidget(ac_class=ImprintAutocomplete),
+        widget=SafeAutocompleteWidget(ac_class=ImprintAutocomplete),
         required=False,
     )
 

--- a/comicsdb/forms/team.py
+++ b/comicsdb/forms/team.py
@@ -1,12 +1,12 @@
-from autocomplete import widgets
 from django.forms import ClearableFileInput, ModelForm
 
 from comicsdb.autocomplete import TeamAutocomplete
 from comicsdb.forms.creator import CreatorsWidget
 from comicsdb.forms.universe import UniversesWidget
+from comicsdb.forms.widgets import SafeAutocompleteWidget
 from comicsdb.models import Team
 
-TeamsWidget = widgets.AutocompleteWidget(
+TeamsWidget = SafeAutocompleteWidget(
     ac_class=TeamAutocomplete,
     attrs={"class": "input"},
     options={"multiselect": True},

--- a/comicsdb/forms/universe.py
+++ b/comicsdb/forms/universe.py
@@ -1,10 +1,10 @@
-from autocomplete import widgets
 from django.forms import ClearableFileInput, ModelForm
 
 from comicsdb.autocomplete import UniverseAutocomplete
+from comicsdb.forms.widgets import SafeAutocompleteWidget
 from comicsdb.models import Universe
 
-UniversesWidget = widgets.AutocompleteWidget(
+UniversesWidget = SafeAutocompleteWidget(
     ac_class=UniverseAutocomplete,
     attrs={"class": "input"},
     options={"multiselect": True},

--- a/comicsdb/forms/widgets.py
+++ b/comicsdb/forms/widgets.py
@@ -1,5 +1,22 @@
+from autocomplete import widgets as ac_widgets
 from django import forms
 from djmoney.forms.widgets import MoneyWidget
+
+
+class SafeAutocompleteWidget(ac_widgets.AutocompleteWidget):
+    """AutocompleteWidget subclass that handles empty-string values gracefully.
+
+    The upstream widget crashes when ``value`` is ``''`` because it passes
+    ``['']`` to ``get_items_from_keys``, which in turn calls
+    ``queryset.filter(id__in=[''])`` and raises a ValueError.  This subclass
+    normalises empty strings (and empty lists) to ``None`` before delegating to
+    the parent so the widget simply renders with no pre-selected item.
+    """
+
+    def get_context(self, name, value, attrs):
+        if value in ("", []):
+            value = None
+        return super().get_context(name, value, attrs)
 
 
 class BulmaMoneyWidget(MoneyWidget):


### PR DESCRIPTION
This PR fixes the autocomplete widget crashing on empty string values

Subclass AutocompleteWidget as SafeAutocompleteWidget in comicsdb/forms/widgets.py to normalise empty string and empty list values to None in get_context, preventing a ValueError when the upstream widget calls queryset.filter(id__in=['']) during form re-render after a failed submission.

Update all forms that use AutocompleteWidget (creator, credits, issue, publisher, series, team, universe) to use SafeAutocompleteWidget.

Fixes Internal Server Error on /series/create/ (and equivalent create/update views) when submitting a form without selecting an autocomplete field value.