### PR TITLE
Enable HTTP2 and gzip compression

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,13 +29,15 @@ server {
 
 server {
     listen 8443 ssl;
+    http2 on;
     server_name metron.cloud www.metron.cloud;
 
     ssl_certificate /etc/letsencrypt/live/metron.cloud-0001/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/metron.cloud-0001/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_ecdh_curve X25519MLKEM768:X25519:prime256v1:secp384r1;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
     ssl_prefer_server_ciphers off;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 1d;
@@ -67,4 +69,11 @@ server {
         proxy_buffers 8 16k;
         proxy_busy_buffers_size 32k;
     }
+
+    gzip on;
+    gzip_comp_level 6;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+    gzip_vary on;
 }


### PR DESCRIPTION
This PR tweaks the nginx config a bit with the aim to improve performance.

1. Enables HTTP/2. The biggest win is multiplexing since sequential requests will reuse one connection instead of opening a new one for each request.
2. Enables gzip. Should lead to API responses that are ~70-80% smaller.
3. SSL tweaks. This brings the config in line with [Mozilla's recommendations](https://ssl-config.mozilla.org/#server=nginx&version=1.27.3&config=intermediate&openssl=3.6.1&hsts&guideline=6.0).