### PR TITLE
Redirect /favicon.ico to static asset in nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -56,6 +56,10 @@ server {
     # Blocked IPs
     deny 121.200.33.119;
 
+    location = /favicon.ico {
+        return 301 https://$host/static/site/img/favicon.ico;
+    }
+
     location / {
         proxy_pass http://metron_web;
         proxy_set_header Host $host;


### PR DESCRIPTION
Browsers always request /favicon.ico directly regardless of the <link> tag in the HTML head, causing 404 noise in the logs. Add an nginx location block to redirect it to the actual favicon in static storage.