### PR TITLE
Block Meta crawlers and enable Open Graph passthrough in Anubis

### DIFF
--- a/anubis/policy.yaml
+++ b/anubis/policy.yaml
@@ -22,7 +22,7 @@ bots:
 
   # Deny Meta/Facebook crawlers (meta-externalagent, facebookexternalhit, FacebookBot).
   - name: deny-meta-crawlers
-    user_agent_regex: meta-externalagent|meta-webindexer|facebookexternalhit|FacebookBot
+    user_agent_regex: meta-externalagent|meta-webindexer|FacebookBot
     action: DENY
 
   # Deny known pathological bots and aggressive scrapers.
@@ -49,6 +49,13 @@ bots:
     action: WEIGH
     weight:
       adjust: 10
+
+# Anubis fetches and caches Open Graph tags from Django and serves them to
+# social media crawlers (Facebook, Twitter/X, Slack, Discord, etc.) so that
+# link previews work without bypassing the challenge entirely.
+openGraph:
+  enabled: true
+  ttl: 24h
 
 # Weight thresholds that determine when to challenge a request.
 # The generic-browser rule above adds weight=10 to browser requests,


### PR DESCRIPTION
## Summary

- Deny Meta/Facebook indexing crawlers (`meta-externalagent`, `meta-webindexer`, `FacebookBot`) that were hammering the site
- Enable Anubis's built-in Open Graph passthrough (`openGraph.enabled: true`, 24h TTL) so social media link previews (Facebook, Twitter/X, Slack, Discord, etc.) continue to work without bypassing the proof-of-work challenge

## Notes

`facebookexternalhit` (Facebook's OG tag fetcher) is intentionally **not** denied — the `openGraph` passthrough handles it so Metron URLs generate correct link previews when shared on Facebook. The heavy indexers doing bulk crawling are what's being blocked.
