### PR TITLE
Disable Anubis OG passthrough to prevent bot attack amplification

### DIFF
--- a/anubis/policy.yaml
+++ b/anubis/policy.yaml
@@ -25,6 +25,12 @@ bots:
     user_agent_regex: meta-externalagent|meta-webindexer|FacebookBot
     action: DENY
 
+  # Deny WordPress path scanners. Metron is a Django app — these paths will
+  # never exist and are purely exploit probes.
+  - name: deny-wordpress-scanners
+    path_regex: wp-includes|wp-admin|wp-login|xmlrpc\.php
+    action: DENY
+
   # Deny known pathological bots and aggressive scrapers.
   - import: (data)/bots/_deny-pathological.yaml
   - import: (data)/bots/aggressive-brazilian-scrapers.yaml
@@ -41,6 +47,14 @@ bots:
   # Allow well-known routes (favicon, robots.txt, .well-known/).
   - import: (data)/common/keep-internet-working.yaml
 
+  # Allow social media OG tag fetchers so link previews work when users share
+  # Metron URLs. These bypass the challenge entirely rather than using the
+  # openGraph passthrough, which would amplify bot attacks by hitting Django
+  # for every challenged request.
+  - name: allow-og-crawlers
+    user_agent_regex: facebookexternalhit|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot
+    action: ALLOW
+
   # Add weight to generic browser-like user agents. Combined with the
   # thresholds below this triggers the proof-of-work challenge for browsers.
   - name: generic-browser
@@ -50,12 +64,10 @@ bots:
     weight:
       adjust: 10
 
-# Anubis fetches and caches Open Graph tags from Django and serves them to
-# social media crawlers (Facebook, Twitter/X, Slack, Discord, etc.) so that
-# link previews work without bypassing the challenge entirely.
-openGraph:
-  enabled: true
-  ttl: 24h
+# OG passthrough is disabled. When enabled, Anubis fetches OG tags from Django
+# for every challenged request, which amplifies bot attacks by doubling Django
+# load. Social media link previews are handled instead by the allow-og-crawlers
+# rule below which lets known OG fetchers bypass the challenge entirely.
 
 # Weight thresholds that determine when to challenge a request.
 # The generic-browser rule above adds weight=10 to browser requests,


### PR DESCRIPTION
## Summary

This PR disables Anubis OG passthrough to prevent bot attack amplification:

- Disable the `openGraph` passthrough feature in the Anubis policy
- Restore explicit `ALLOW` rules for known social media OG crawlers (`facebookexternalhit`, `Twitterbot`, `LinkedInBot`, `Slackbot`, `Discordbot`, `TelegramBot`)

## Problem

During a bot attack, the `openGraph` passthrough amplifies load on Django. For every challenged request, Anubis makes an additional internal HTTP request to Django to fetch OG tags to embed in the challenge page. Under attack conditions this causes Django to time out (`context deadline exceeded`), effectively doubling the damage from bot traffic.

## Solution

Disable `openGraph` passthrough so challenged requests are served entirely from Anubis without hitting Django at all. Social media link previews are restored via explicit `ALLOW` rules for known OG crawlers, which is the safer approach — only verified crawler user agents bypass the challenge, and there is no amplification risk during attacks.
