### PR TITLE
Increase S3 retry attempts to 3 to handle intermittent connect timeouts

### DIFF
--- a/metron/settings.py
+++ b/metron/settings.py
@@ -331,7 +331,7 @@ if not DEBUG:
     AWS_S3_CLIENT_CONFIG = BotocoreConfig(
         connect_timeout=5,
         read_timeout=10,
-        retries={"max_attempts": 2, "mode": "standard"},
+        retries={"max_attempts": 3, "mode": "standard"},
         # Prevent stale connections in boto3's pool — rootless Podman's
         # user-space network stack (pasta) can silently drop idle TCP connections.
         tcp_keepalive=True,


### PR DESCRIPTION
Connectivity tests show ~4% of new TCP connections from the metron-web container to DigitalOcean Spaces fail due to the pasta user-space network stack. With 3 attempts the probability of all retries failing drops to ~0.006%, making S3 errors effectively invisible to users.