### PR TITLE
Add UK publisher and GBP currency support

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -365,7 +365,8 @@ The Issue endpoint supports the most comprehensive filtering options:
 
 - All list fields plus:
     - `desc` - Issue description
-    - `price` - Cover price
+    - `price` - Cover price amount as a decimal string (e.g. `"3.99"`). See `price_currency` for the currency.
+    - `price_currency` - ISO 4217 currency code for the cover price (e.g. `"USD"`, `"GBP"`).
     - `sku` - Distributor SKU
     - `isbn` - ISBN number
     - `upc` - UPC code
@@ -383,6 +384,15 @@ The Issue endpoint supports the most comprehensive filtering options:
     - `cover_hash` - Perceptual image hash
     - `foc_date` - Final order cutoff date
     - `resource_url` - Link to web UI
+
+**Cover Price (Write):**
+
+The `price` field accepts two formats on POST/PATCH:
+
+- **Decimal string** — defaults to USD: `"3.99"`
+- **Object** — for non-USD prices: `{"amount": 3.99, "currency": "GBP"}`
+
+Supported currencies: `USD`, `GBP`. Unsupported currency codes will return a `400 Bad Request`.
 
 **Cover Hash:**
 The `cover_hash` field contains a perceptual hash generated using [ImageHash](https://github.com/JohannesBuchner/imagehash). This allows for finding similar or duplicate covers.
@@ -445,11 +455,16 @@ Comic book publishers.
 **Detail Response Fields:**
 
 - All list fields plus:
+    - `country` - ISO 3166-1 alpha-2 country code (e.g. `"US"`, `"GB"`)
     - `desc` - Description
     - `image` - Publisher logo URL
     - `cv_id` - Comic Vine ID
     - `gcd_id` - Grand Comics Database ID
     - `resource_url` - Link to web UI
+
+**Country (Write):**
+
+The `country` field on POST/PATCH accepts ISO 3166-1 alpha-2 codes. Currently supported values are `"US"` (United States) and `"GB"` (United Kingdom). Other values will return a `400 Bad Request`.
 
 **Example:**
 ```bash
@@ -1913,6 +1928,11 @@ For questions, issues, or feature requests:
 ---
 
 ## Changelog
+
+### Version 1.2
+- UK publisher support: `country` field on Publisher now accepts `"GB"` in addition to `"US"`
+- Issue `price` field now accepts GBP via `{"amount": 3.99, "currency": "GBP"}` on write
+- Issue detail response now includes `price_currency` field
 
 ### Version 1.1
 - Conditional request support (`If-Modified-Since` / `Last-Modified`) on all detail endpoints

--- a/api/v1_0/serializers/issue.py
+++ b/api/v1_0/serializers/issue.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from django.conf import settings
 from djmoney.money import Money
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -19,13 +20,34 @@ from comicsdb.models import Issue, Series, Variant
 
 @extend_schema_field(
     {
-        "type": "string",
-        "format": "decimal",
-        "pattern": r"^\d+\.\d{2}$",
-        "example": "3.99",
+        "oneOf": [
+            {
+                "type": "string",
+                "format": "decimal",
+                "pattern": r"^\d+\.\d{2}$",
+                "example": "3.99",
+                "description": "Decimal string — defaults to USD (e.g. '3.99').",
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "amount": {"type": "number", "example": 3.99},
+                    "currency": {
+                        "type": "string",
+                        "enum": ["USD", "GBP"],
+                        "example": "GBP",
+                    },
+                },
+                "required": ["amount", "currency"],
+                "description": "Object format for non-USD prices (e.g. GBP for UK publishers).",
+            },
+        ],
         "description": (
-            "Price amount as decimal string (e.g., '3.99'). "
-            "Currency information available in price_currency field."
+            "Cover price. For reads, returns the amount as a decimal string; "
+            "see price_currency for the currency. "
+            "For writes, pass a plain decimal string (defaults to USD) or "
+            '{"amount": 3.99, "currency": "GBP"} for UK publishers. '
+            "Supported currencies: USD, GBP."
         ),
         "nullable": True,
     }
@@ -60,7 +82,7 @@ class PriceField(serializers.Field):
         Accepts:
         - None or empty string: returns None (blank price)
         - Decimal/float/string: "3.99" (defaults to USD)
-        - Dict: {"amount": 3.99, "currency": "USD"}
+        - Dict: {"amount": 3.99, "currency": "GBP"} (supported: USD, GBP)
         """
         # Handle None, empty string, or empty dict
         if data in (None, "", {}):
@@ -74,6 +96,11 @@ class PriceField(serializers.Field):
             # Allow empty/null amount in dict format
             if amount in (None, ""):
                 return None
+
+            if currency not in settings.CURRENCIES:
+                raise serializers.ValidationError(
+                    f"Invalid currency '{currency}'. Supported: {', '.join(settings.CURRENCIES)}"
+                )
 
             try:
                 return Money(Decimal(str(amount)), currency)

--- a/api/views.py
+++ b/api/views.py
@@ -6,7 +6,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
-from rest_framework.parsers import FormParser, MultiPartParser
+from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework_condition import last_modified
@@ -334,7 +334,7 @@ class IssueViewSet(
 
     queryset = Issue.objects.all()
     filterset_class = IssueFilter
-    parser_classes = (MultiPartParser, FormParser)
+    parser_classes = (JSONParser, MultiPartParser, FormParser)
 
     def get_queryset(self):
         if self.action == "list":

--- a/comicsdb/forms/issue.py
+++ b/comicsdb/forms/issue.py
@@ -97,7 +97,7 @@ class IssueForm(ModelForm):
             "alt_number": "Primarily used for legacy numbering for DC and Marvel comics.",
             "name": "Separate multiple story titles by a semicolon",
             "title": "Only used with Collected Editions like a Trade Paperback.",
-            "price": "In United States currency",
+            "price": "USD for US publishers, GBP for UK publishers",
             "reprints": "Search using 'Series Name (Year) #Number' format.",
             "foc_date": "This date should be earlier than the store date",
         }

--- a/comicsdb/forms/publisher.py
+++ b/comicsdb/forms/publisher.py
@@ -21,8 +21,8 @@ class PublisherForm(ModelForm):
     field_order = ["name", "desc", "founded", "country", "cv_id", "gcd_id", "image"]
 
     def clean_country(self):
-        # Only allow US publishers for now.
         country = self.cleaned_data["country"]
-        if country and country != "US":
-            raise ValidationError("Currently only US Publishers are supported")
+        allowed = {"US", "GB"}
+        if country and str(country) not in allowed:
+            raise ValidationError("Currently only US and UK Publishers are supported")
         return country

--- a/metron/settings.py
+++ b/metron/settings.py
@@ -151,7 +151,7 @@ DATABASES = {
 }
 
 # django-money settings
-CURRENCIES = ("USD",)  # Add other currencies as needed: ('USD', 'GBP', 'EUR')
+CURRENCIES = ("USD", "GBP")
 DEFAULT_CURRENCY = "USD"
 
 # django-wiki'

--- a/tests/comicsdb/README.md
+++ b/tests/comicsdb/README.md
@@ -13,7 +13,7 @@ Tests for the REST API endpoints ensuring proper authentication, authorization, 
 - [test_api_creator.py](test_api_creator.py) - Creator (writers, artists, etc.) API endpoints
 - [test_api_credits.py](test_api_credits.py) - Credits API endpoints
 - [test_api_imprint.py](test_api_imprint.py) - Publisher imprint API endpoints
-- [test_api_issue.py](test_api_issue.py) - Comic issue API endpoints
+- [test_api_issue.py](test_api_issue.py) - Comic issue API endpoints including cover price and currency (USD/GBP)
 - [test_api_publisher.py](test_api_publisher.py) - Publisher API endpoints
 - [test_api_role.py](test_api_role.py) - Creator role API endpoints
 - [test_api_series.py](test_api_series.py) - Comic series API endpoints
@@ -45,6 +45,7 @@ Tests for Django models, business logic, and database operations:
 
 ### Form Tests
 - [test_issue_form.py](test_issue_form.py) - Issue form validation and handling
+- [test_publisher_form.py](test_publisher_form.py) - Publisher form validation including country restrictions
 
 ### Management Command Tests
 - [test_management.py](test_management.py) - Django management commands

--- a/tests/comicsdb/test_api_issue.py
+++ b/tests/comicsdb/test_api_issue.py
@@ -3,8 +3,11 @@ from decimal import Decimal
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
+from djmoney.money import Money
 from rest_framework import status
 
+from comicsdb.models import Issue
 from comicsdb.models.arc import Arc
 from comicsdb.models.series import Series
 from comicsdb.models.universe import Universe
@@ -103,3 +106,133 @@ def test_get_invalid_single_arc(api_client_with_credentials):
 def test_unauthorized_detail_view_url(api_client, issue_with_arc):
     resp = api_client.get(reverse("api:issue-detail", kwargs={"pk": issue_with_arc.pk}))
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+class TestIssuePriceField:
+    @pytest.fixture
+    def usd_issue(self, create_user, fc_series):
+        user = create_user()
+        return Issue.objects.create(
+            series=fc_series,
+            number="10",
+            slug="final-crisis-10",
+            cover_date=timezone.now().date(),
+            price=Money(Decimal("3.99"), "USD"),
+            edited_by=user,
+            created_by=user,
+        )
+
+    @pytest.fixture
+    def gbp_issue(self, create_user, fc_series):
+        user = create_user()
+        return Issue.objects.create(
+            series=fc_series,
+            number="11",
+            slug="final-crisis-11",
+            cover_date=timezone.now().date(),
+            price=Money(Decimal("3.99"), "GBP"),
+            edited_by=user,
+            created_by=user,
+        )
+
+    @pytest.fixture
+    def base_issue_data(self, fc_series):
+        return {
+            "series": fc_series.id,
+            "number": "99",
+            "cover_date": date(2024, 1, 1),
+        }
+
+    # Retrieve tests
+
+    def test_retrieve_usd_price_amount(self, api_client_with_credentials, usd_issue):
+        resp = api_client_with_credentials.get(
+            reverse("api:issue-detail", kwargs={"pk": usd_issue.pk})
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["price"] == "3.99"
+
+    def test_retrieve_usd_price_currency(self, api_client_with_credentials, usd_issue):
+        resp = api_client_with_credentials.get(
+            reverse("api:issue-detail", kwargs={"pk": usd_issue.pk})
+        )
+        assert resp.data["price_currency"] == "USD"
+
+    def test_retrieve_gbp_price_amount(self, api_client_with_credentials, gbp_issue):
+        resp = api_client_with_credentials.get(
+            reverse("api:issue-detail", kwargs={"pk": gbp_issue.pk})
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["price"] == "3.99"
+
+    def test_retrieve_gbp_price_currency(self, api_client_with_credentials, gbp_issue):
+        resp = api_client_with_credentials.get(
+            reverse("api:issue-detail", kwargs={"pk": gbp_issue.pk})
+        )
+        assert resp.data["price_currency"] == "GBP"
+
+    # Patch tests
+
+    def test_patch_usd_string_price(self, api_client_with_staff_credentials, usd_issue):
+        url = reverse("api:issue-detail", kwargs={"pk": usd_issue.pk})
+        resp = api_client_with_staff_credentials.patch(url, data={"price": "4.99"})
+        assert resp.status_code == status.HTTP_200_OK
+        detail = api_client_with_staff_credentials.get(url)
+        assert detail.data["price"] == "4.99"
+        assert detail.data["price_currency"] == "USD"
+
+    def test_patch_gbp_dict_price(self, api_client_with_staff_credentials, usd_issue):
+        url = reverse("api:issue-detail", kwargs={"pk": usd_issue.pk})
+        resp = api_client_with_staff_credentials.patch(
+            url,
+            data={"price": {"amount": 3.99, "currency": "GBP"}},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        detail = api_client_with_staff_credentials.get(url)
+        assert detail.data["price"] == "3.99"
+        assert detail.data["price_currency"] == "GBP"
+
+    def test_patch_invalid_currency_returns_400(self, api_client_with_staff_credentials, usd_issue):
+        resp = api_client_with_staff_credentials.patch(
+            reverse("api:issue-detail", kwargs={"pk": usd_issue.pk}),
+            data={"price": {"amount": 3.99, "currency": "EUR"}},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    # Post tests
+
+    def test_post_usd_string_price(self, api_client_with_staff_credentials, base_issue_data):
+        base_issue_data["price"] = "3.99"
+        resp = api_client_with_staff_credentials.post(
+            reverse("api:issue-list"), data=base_issue_data
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        detail = api_client_with_staff_credentials.get(
+            reverse("api:issue-detail", kwargs={"pk": resp.data["id"]})
+        )
+        assert detail.data["price"] == "3.99"
+        assert detail.data["price_currency"] == "USD"
+
+    def test_post_gbp_dict_price(self, api_client_with_staff_credentials, base_issue_data):
+        base_issue_data["price"] = {"amount": 3.99, "currency": "GBP"}
+        resp = api_client_with_staff_credentials.post(
+            reverse("api:issue-list"), data=base_issue_data, format="json"
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        detail = api_client_with_staff_credentials.get(
+            reverse("api:issue-detail", kwargs={"pk": resp.data["id"]})
+        )
+        assert detail.data["price"] == "3.99"
+        assert detail.data["price_currency"] == "GBP"
+
+    def test_post_invalid_currency_returns_400(
+        self, api_client_with_staff_credentials, base_issue_data
+    ):
+        base_issue_data["price"] = {"amount": 3.99, "currency": "EUR"}
+        resp = api_client_with_staff_credentials.post(
+            reverse("api:issue-list"), data=base_issue_data, format="json"
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/comicsdb/test_publisher_form.py
+++ b/tests/comicsdb/test_publisher_form.py
@@ -1,0 +1,28 @@
+import pytest
+
+from comicsdb.forms.publisher import PublisherForm
+
+
+class TestPublisherFormCountry:
+    @pytest.fixture
+    def base_data(self):
+        return {
+            "name": "Test Publisher",
+            "founded": 1990,
+        }
+
+    @pytest.mark.parametrize("country", ["US", "GB"])
+    def test_allowed_countries(self, base_data, country):
+        base_data["country"] = country
+        form = PublisherForm(data=base_data)
+        assert "country" not in form.errors
+
+    def test_disallowed_country_raises_error(self, base_data):
+        base_data["country"] = "CA"
+        form = PublisherForm(data=base_data)
+        assert "country" in form.errors
+
+    def test_disallowed_country_error_message(self, base_data):
+        base_data["country"] = "DE"
+        form = PublisherForm(data=base_data)
+        assert "Currently only US and UK Publishers are supported" in form.errors["country"]


### PR DESCRIPTION
## Summary

- Allow `"GB"` as a valid country for publishers (previously only `"US"` was accepted)
- Add GBP to supported currencies (`CURRENCIES` setting) so UK issue cover prices can be stored and submitted
- Add `JSONParser` to `IssueViewSet` so the dict-format price input (`{"amount": 3.99, "currency": "GBP"}`) works over the API
- Expose `price_currency` in the issue detail API response so clients can read back the currency alongside the amount
- Validate submitted currency codes against `settings.CURRENCIES`, returning 400 for unsupported values
