### PR TITLE
Fix intermittent S3 timeouts by giving metron-web Network=host

### DIFF
--- a/.quadlet/metron-anubis.container
+++ b/.quadlet/metron-anubis.container
@@ -9,7 +9,7 @@ ContainerName=metron-anubis
 Network=metron.network
 PublishPort=127.0.0.1:8923:8923
 Environment=BIND=:8923
-Environment=TARGET=http://metron-web:8000
+Environment=TARGET=http://host.containers.internal:8000
 Environment=POLICY_FNAME=/etc/anubis/policy.yaml
 EnvironmentFile=%h/.config/containers/metron.env
 Volume=%h/metron/anubis/policy.yaml:/etc/anubis/policy.yaml:ro,Z

--- a/.quadlet/metron-postgres.container
+++ b/.quadlet/metron-postgres.container
@@ -6,6 +6,7 @@ After=network-online.target
 Image=docker.io/library/postgres:16
 ContainerName=metron-postgres
 Network=metron.network
+PublishPort=127.0.0.1:5432:5432
 LogDriver=journald
 Volume=metron-postgres.volume:/var/lib/postgresql/data
 EnvironmentFile=%h/.config/containers/metron.env

--- a/.quadlet/metron-redis.container
+++ b/.quadlet/metron-redis.container
@@ -6,6 +6,7 @@ After=network-online.target
 Image=docker.io/library/redis:7-alpine
 ContainerName=metron-redis
 Network=metron.network
+PublishPort=127.0.0.1:6379:6379
 LogDriver=journald
 Volume=metron-redis.volume:/data
 Exec=redis-server --appendonly yes

--- a/.quadlet/metron-web.container
+++ b/.quadlet/metron-web.container
@@ -6,8 +6,7 @@ Requires=metron-postgres.service metron-redis.service
 [Container]
 Image=localhost/metron:latest
 ContainerName=metron-web
-Network=metron.network
-PublishPort=127.0.0.1:8000:8000
+Network=host
 EnvironmentFile=%h/.config/containers/metron.env
 LogDriver=journald
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -53,23 +53,28 @@ with Quadlet (systemd-managed containers).
 internet (80/443) → firewalld → nginx container (host network, :8080/:8443)
                                       ↓ 127.0.0.1:8923
                              metron-anubis (Anubis, metron.network)
-                                      ↓ metron-web:8000
-                              metron-web (gunicorn, metron.network)
-                                      ↓
+                                      ↓ host.containers.internal:8000
+                              metron-web (gunicorn, host network, :8000)
+                                      ↓ 127.0.0.1:5432 / 127.0.0.1:6379
                           metron-postgres  metron-redis
-                              (metron.network)
+                              (metron.network, published to loopback)
 ```
 
-The nginx container uses `Network=host` so it sits directly on the host network
-stack, which allows real client IPs to be logged rather than pasta's internal
-NAT addresses. The metron-anubis, metron-web, metron-postgres, and metron-redis
-containers share the `metron` bridge network; metron-anubis is published on
-`127.0.0.1:8923` so nginx can reach it via the loopback interface. Anubis
-enforces a proof-of-work challenge for browser traffic and forwards to
-metron-web; API requests (`/api/`) are exempted and pass through unconditionally.
-Static and media files are served from DigitalOcean Spaces (S3-compatible);
-the containers have no local file storage responsibility beyond database and
-cache data volumes.
+Both nginx and metron-web use `Network=host` so they sit directly on the host
+network stack. This routes outbound connections (e.g. to DigitalOcean Spaces S3)
+through the kernel network stack rather than through pasta's user-space proxy,
+which eliminates intermittent connect timeouts. The trade-off is that
+`Network=host` containers cannot use Podman's container-name DNS resolution;
+any service metron-web needs to reach must be published to the host loopback
+and addressed as `127.0.0.1`. metron-postgres and metron-redis
+remain on the `metron` bridge network but publish their ports to `127.0.0.1`
+so metron-web can reach them via the host loopback. metron-anubis stays on the
+bridge network and is published on `127.0.0.1:8923` so nginx can reach it;
+it forwards to metron-web via `host.containers.internal:8000`. Anubis enforces
+a proof-of-work challenge for browser traffic; API requests (`/api/`) pass
+through unconditionally. Static and media files are served from DigitalOcean
+Spaces (S3-compatible); the containers have no local file storage responsibility
+beyond database and cache data volumes.
 
 ---
 

--- a/metron.env.example
+++ b/metron.env.example
@@ -11,11 +11,12 @@ POSTGRES_PASSWORD=changeme
 DB_NAME=metron
 DB_USER=metron
 DB_PASSWORD=changeme
-DB_HOST=metron-postgres
+# metron-web runs with Network=host; postgres/redis publish to the host loopback.
+DB_HOST=127.0.0.1
 
 # ── Redis ──────────────────────────────────────────────────────────────────────
-REDIS_URL=redis://metron-redis:6379/0
-THUMBNAIL_REDIS_HOST=metron-redis
+REDIS_URL=redis://127.0.0.1:6379/0
+THUMBNAIL_REDIS_HOST=127.0.0.1
 
 # ── Django ─────────────────────────────────────────────────────────────────────
 SECRET_KEY=changeme


### PR DESCRIPTION
## Summary

- Switch `metron-web` from `Network=metron.network` to `Network=host` so outbound S3 traffic (sorl-thumbnail, media uploads) goes through the kernel network stack instead of pasta's user-space proxy
- Publish postgres (5432) and redis (6379) to `127.0.0.1` so metron-web can reach them via the host loopback; update `DB_HOST`, `REDIS_URL`, and `THUMBNAIL_REDIS_HOST` in `metron.env.example` accordingly 
- Update Anubis `TARGET` to `http://host.containers.internal:8000` since metron-web is no longer addressable by container name from the bridge network

## Background

Switching metron-web's outbound S3 connections from pasta user-space networking to the host kernel stack. Testing confirmed ~4% failure rate on S3 connects inside the container regardless of whether pasta or slirp4netns was used, while direct host tests had 0 failures.

## Deploy

1. Copy updated quadlet files
```bash
cp ~/metron/.quadlet/*.container ~/.config/containers/systemd/
```

2. Update metron.env — change three values:
    DB_HOST=127.0.0.1
    REDIS_URL=redis://127.0.0.1:6379/0
    THUMBNAIL_REDIS_HOST=127.0.0.1

3. Reload and restart everything
```bash
systemctl --user daemon-reload
```
```bash
systemctl --user restart metron-postgres metron-redis metron-web metron-anubis
```

4. Verify
```bash
systemctl --user status metron-web metron-anubis
```
```bash
journalctl CONTAINER_NAME=metron-web -n 30
```

## How to Test

- [x] `systemctl --user status metron-web metron-anubis` — both active
- [x] Site loads through nginx → Anubis → metron-web
- [x] Upload a cover image — no S3 `ConnectTimeoutError` in logs
- [x] `journalctl CONTAINER_NAME=metron-web -n 50` — no timeout errors
