### PR TITLE
Move keep-internet-working.yaml before deny rules in Anubis policy

### DIFF
--- a/anubis/policy.yaml
+++ b/anubis/policy.yaml
@@ -20,6 +20,10 @@ bots:
         - '"Hx-Request" in headers'
         - 'headers["Hx-Request"] == "true"'
 
+  # Allow well-known routes (favicon, robots.txt, .well-known/) before any deny
+  # rules so crawlers can always fetch these regardless of user-agent.
+  - import: (data)/common/keep-internet-working.yaml
+
   # Deny Meta/Facebook crawlers (meta-externalagent, facebookexternalhit, FacebookBot).
   - name: deny-meta-crawlers
     user_agent_regex: meta-externalagent|meta-webindexer|FacebookBot
@@ -43,9 +47,6 @@ bots:
 
   # Challenge Firefox AI previews.
   - import: (data)/clients/x-firefox-ai.yaml
-
-  # Allow well-known routes (favicon, robots.txt, .well-known/).
-  - import: (data)/common/keep-internet-working.yaml
 
   # Allow social media OG tag fetchers so link previews work when users share
   # Metron URLs. These bypass the challenge entirely rather than using the


### PR DESCRIPTION
This change ensures `robots.txt` (and `favicon`/`.well-known/`) are always served regardless of user-agent, since rules are evaluated in order and a denied UA would never reach the allow rule (and thus keep scraping since it can't read `robots.txt` and see that it's not allowed to scrape). 

In the nginx logs we have repeated visits from `GPTBot` despite it being blocked by `robots.txt` (and their docs saying they do respect this file). Looking at the Anubis logs, a lot of requests for this file is currently being denied by Anubis, which would explain why we see blocked user-agents still visiting us.