### PR TITLE
Add `creator_id` filter to Issue and Series API endpoints

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -336,6 +336,10 @@ The Issue endpoint supports the most comprehensive filtering options:
 
 - `rating` - Content rating (exact match)
 
+**Creator Filters:**
+
+- `creator_id` - Creator Metron ID (exact match, filters issues with a credit for this creator)
+
 **Metadata:**
 
 - `modified_gt` - Modified after datetime
@@ -416,6 +420,9 @@ GET /api/issue/?cover_year=2024&cover_month=12
 
 # Find by UPC
 GET /api/issue/?upc=75960609558200111
+
+# Get all issues with a credit for a specific creator
+GET /api/issue/?creator_id=123
 ```
 
 ---
@@ -571,6 +578,10 @@ Comic book series.
 - `gcd_id` - Grand Comics Database ID
 - `missing_gcd_id` - Boolean, series without GCD ID
 
+**Creator Filters:**
+
+- `creator_id` - Creator Metron ID (exact match, filters series containing at least one issue with a credit for this creator)
+
 **Metadata:**
 
 - `modified_gt` - Modified after datetime
@@ -631,6 +642,9 @@ GET /api/series/?year_began=2020
 
 # Get issues in a series
 GET /api/series/123/issue_list/
+
+# Get all series with at least one issue credited to a specific creator
+GET /api/series/?creator_id=123
 ```
 
 ---
@@ -1928,6 +1942,10 @@ For questions, issues, or feature requests:
 ---
 
 ## Changelog
+
+### Version 1.3
+- Added `creator_id` filter to Issue endpoint (filters issues with a credit for the given creator)
+- Added `creator_id` filter to Series endpoint (filters series containing at least one issue credited to the given creator)
 
 ### Version 1.2
 - UK publisher support: `country` field on Publisher now accepts `"GB"` in addition to `"US"`

--- a/comicsdb/filters/issue.py
+++ b/comicsdb/filters/issue.py
@@ -77,6 +77,9 @@ class IssueFilter(df.rest_framework.FilterSet):
     cover_hash = df.rest_framework.CharFilter(
         label="Cover Hash", field_name="cover_hash", lookup_expr="iexact"
     )
+    creator_id = df.rest_framework.NumberFilter(
+        label="Creator Metron ID", field_name="creators__id", lookup_expr="exact", distinct=True
+    )
 
     class Meta:
         model = Issue

--- a/comicsdb/filters/series.py
+++ b/comicsdb/filters/series.py
@@ -39,6 +39,12 @@ class SeriesFilter(filters.FilterSet):
         label="Grand Comics Database ID", field_name="gcd_id", lookup_expr="exact"
     )
     missing_gcd_id = filters.filters.BooleanFilter(field_name="gcd_id", lookup_expr="isnull")
+    creator_id = filters.filters.NumberFilter(
+        label="Creator Metron ID",
+        field_name="issues__creators__id",
+        lookup_expr="exact",
+        distinct=True,
+    )
 
     class Meta:
         model = Series

--- a/tests/comicsdb/test_api_issue.py
+++ b/tests/comicsdb/test_api_issue.py
@@ -7,8 +7,10 @@ from django.utils import timezone
 from djmoney.money import Money
 from rest_framework import status
 
-from comicsdb.models import Issue
+from comicsdb.models import Credits, Issue
 from comicsdb.models.arc import Arc
+from comicsdb.models.creator import Creator
+from comicsdb.models.credits import Role
 from comicsdb.models.series import Series
 from comicsdb.models.universe import Universe
 
@@ -236,3 +238,22 @@ class TestIssuePriceField:
             reverse("api:issue-list"), data=base_issue_data, format="json"
         )
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_filter_by_creator_id(
+    api_client_with_credentials, issue_with_arc: Issue, john_byrne: Creator, writer: Role
+):
+    credit = Credits.objects.create(issue=issue_with_arc, creator=john_byrne)
+    credit.role.add(writer)
+    resp = api_client_with_credentials.get(reverse("api:issue-list"), {"creator_id": john_byrne.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == issue_with_arc.id
+
+
+def test_filter_by_creator_id_no_match(
+    api_client_with_credentials, issue_with_arc: Issue, john_byrne: Creator
+):
+    resp = api_client_with_credentials.get(reverse("api:issue-list"), {"creator_id": john_byrne.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0

--- a/tests/comicsdb/test_api_series.py
+++ b/tests/comicsdb/test_api_series.py
@@ -8,7 +8,9 @@ from django.urls import reverse
 from rest_framework import status
 
 from api.v1_0.serializers import SeriesListSerializer
-from comicsdb.models import Series
+from comicsdb.models import Credits, Series
+from comicsdb.models.creator import Creator
+from comicsdb.models.credits import Role
 from comicsdb.models.publisher import Publisher
 from comicsdb.models.series import SeriesType
 
@@ -110,3 +112,30 @@ def test_series_search(api_client_with_credentials, bat_sups_series, fc_series):
     serializer = SeriesListSerializer(expected, many=True)
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["results"] == serializer.data
+
+
+def test_filter_by_creator_id(
+    api_client_with_credentials,
+    fc_series: Series,
+    issue_with_arc,
+    john_byrne: Creator,
+    writer: Role,
+):
+    credit = Credits.objects.create(issue=issue_with_arc, creator=john_byrne)
+    credit.role.add(writer)
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"creator_id": john_byrne.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == fc_series.id
+
+
+def test_filter_by_creator_id_no_match(
+    api_client_with_credentials, fc_series: Series, john_byrne: Creator
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"creator_id": john_byrne.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0


### PR DESCRIPTION
## Summary

- Adds a `creator_id` filter to the Issue endpoint that returns issues with a credit for the specified creator (via the `Credits` through-table)
- Adds a `creator_id` filter to the Series endpoint that returns series containing at least one issue credited to the specified creator (traverses `issues__creators__id`)
- Both filters use `distinct=True` to prevent duplicate results from the M2M joins
- Documents both filters in `api/README.md` with usage examples and a Version 1.3 changelog entry