### PR TITLE
Add `year_end` to Series list API endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -590,18 +590,10 @@ Comic book series.
 ```json
 {
   "id": 1,
-  "series_type": {
-    "id": 1,
-    "name": "Ongoing Series"
-  },
-  "publisher": {
-    "id": 10,
-    "name": "Marvel Comics"
-  },
-  "name": "Amazing Spider-Man",
-  "volume": 1,
+  "series": "Amazing Spider-Man (1963)",
   "year_began": 1963,
   "year_end": null,
+  "volume": 1,
   "issue_count": 900,
   "modified": "2025-01-15T10:30:00Z"
 }
@@ -1942,6 +1934,9 @@ For questions, issues, or feature requests:
 ---
 
 ## Changelog
+
+### Version 1.4
+- Added `year_end` field to Series list endpoint (nullable; present when a series has ended)
 
 ### Version 1.3
 - Added `creator_id` filter to Issue endpoint (filters issues with a credit for the given creator)

--- a/api/v1_0/serializers/series.py
+++ b/api/v1_0/serializers/series.py
@@ -12,7 +12,7 @@ class SeriesListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Series
-        fields = ("id", "series", "year_began", "volume", "issue_count", "modified")
+        fields = ("id", "series", "year_began", "year_end", "volume", "issue_count", "modified")
 
 
 class SeriesTypeSerializer(serializers.ModelSerializer):

--- a/tests/comicsdb/test_api_series.py
+++ b/tests/comicsdb/test_api_series.py
@@ -139,3 +139,31 @@ def test_filter_by_creator_id_no_match(
     )
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["count"] == 0
+
+
+def test_list_series_year_end_null(api_client_with_credentials, fc_series: Series):
+    resp = api_client_with_credentials.get(reverse("api:series-list"))
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["results"][0]["year_end"] is None
+
+
+def test_list_series_year_end_set(
+    api_client_with_credentials, fc_series: Series, create_user, dc_comics, single_issue_type
+):
+    user = create_user()
+    Series.objects.create(
+        name="Completed Series",
+        slug="completed-series",
+        publisher=dc_comics,
+        volume="1",
+        year_began=2000,
+        year_end=2005,
+        series_type=single_issue_type,
+        status=Series.Status.COMPLETED,
+        edited_by=user,
+        created_by=user,
+    )
+    resp = api_client_with_credentials.get(reverse("api:series-list"))
+    assert resp.status_code == status.HTTP_200_OK
+    completed = next(r for r in resp.data["results"] if r["year_end"] is not None)
+    assert completed["year_end"] == 2005


### PR DESCRIPTION
## Summary

- Adds the nullable `year_end` field to `SeriesListSerializer` so clients can determine when a series ended without needing to fetch the detail endpoint
- Adds tests covering both the null case (ongoing series) and the set case (completed series)
- Fixes the Series list response example in the API README and adds a v1.4 changelog entry

## Notes

This is a non-breaking change — existing clients that don't use `year_end` will simply ignore the new field.
