### PR TITLE
Add new filter params to Issue and Series API endpoints

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -336,9 +336,16 @@ The Issue endpoint supports the most comprehensive filtering options:
 
 - `rating` - Content rating (exact match)
 
-**Creator Filters:**
+**Creator/Role Filters:**
 
 - `creator_id` - Creator Metron ID (exact match, filters issues with a credit for this creator)
+- `role_id` - Role Metron ID (filters issues where a creator has this role; accepts a single ID or multiple comma-separated IDs, e.g. `?role_id=1,2`)
+
+**Character/Team/Universe Filters:**
+
+- `character_id` - Character Metron ID (exact match)
+- `team_id` - Team Metron ID (exact match)
+- `universe_id` - Universe Metron ID (exact match)
 
 **Metadata:**
 
@@ -423,6 +430,21 @@ GET /api/issue/?upc=75960609558200111
 
 # Get all issues with a credit for a specific creator
 GET /api/issue/?creator_id=123
+
+# Get all issues where a creator has a specific role
+GET /api/issue/?role_id=1
+
+# Get all issues where a creator has any of several roles (comma-separated)
+GET /api/issue/?role_id=1,2
+
+# Get all issues featuring a specific character
+GET /api/issue/?character_id=456
+
+# Get all issues featuring a specific team
+GET /api/issue/?team_id=789
+
+# Get all issues set in a specific universe
+GET /api/issue/?universe_id=10
 ```
 
 ---
@@ -560,6 +582,7 @@ Comic book series.
 
 - `publisher_id` - Publisher Metron ID
 - `publisher_name` - Publisher name (partial match)
+- `imprint_id` - Imprint Metron ID
 - `imprint_name` - Imprint name (partial match)
 
 **Series Type:**
@@ -578,9 +601,12 @@ Comic book series.
 - `gcd_id` - Grand Comics Database ID
 - `missing_gcd_id` - Boolean, series without GCD ID
 
-**Creator Filters:**
+**Creator/Character/Team/Universe Filters:**
 
 - `creator_id` - Creator Metron ID (exact match, filters series containing at least one issue with a credit for this creator)
+- `character_id` - Character Metron ID (exact match, filters series containing at least one issue featuring this character)
+- `team_id` - Team Metron ID (exact match, filters series containing at least one issue featuring this team)
+- `universe_id` - Universe Metron ID (exact match, filters series containing at least one issue set in this universe)
 
 **Metadata:**
 
@@ -637,6 +663,18 @@ GET /api/series/123/issue_list/
 
 # Get all series with at least one issue credited to a specific creator
 GET /api/series/?creator_id=123
+
+# Get all series filtered by imprint
+GET /api/series/?imprint_id=5
+
+# Get all series featuring a specific character
+GET /api/series/?character_id=456
+
+# Get all series featuring a specific team
+GET /api/series/?team_id=789
+
+# Get all series set in a specific universe
+GET /api/series/?universe_id=10
 ```
 
 ---
@@ -1934,6 +1972,11 @@ For questions, issues, or feature requests:
 ---
 
 ## Changelog
+
+### Version 1.5
+- Added `character_id`, `team_id`, and `universe_id` filters to Issue endpoint
+- Added `role_id` filter to Issue endpoint (accepts a single ID or multiple comma-separated IDs)
+- Added `imprint_id`, `character_id`, `team_id`, and `universe_id` filters to Series endpoint
 
 ### Version 1.4
 - Added `year_end` field to Series list endpoint (nullable; present when a series has ended)

--- a/api/README.md
+++ b/api/README.md
@@ -601,9 +601,10 @@ Comic book series.
 - `gcd_id` - Grand Comics Database ID
 - `missing_gcd_id` - Boolean, series without GCD ID
 
-**Creator/Character/Team/Universe Filters:**
+**Creator/Role/Character/Team/Universe Filters:**
 
 - `creator_id` - Creator Metron ID (exact match, filters series containing at least one issue with a credit for this creator)
+- `role_id` - Role Metron ID (filters series where a creator has this role; accepts a single ID or multiple comma-separated IDs, e.g. `?role_id=1,2`)
 - `character_id` - Character Metron ID (exact match, filters series containing at least one issue featuring this character)
 - `team_id` - Team Metron ID (exact match, filters series containing at least one issue featuring this team)
 - `universe_id` - Universe Metron ID (exact match, filters series containing at least one issue set in this universe)
@@ -675,6 +676,12 @@ GET /api/series/?team_id=789
 
 # Get all series set in a specific universe
 GET /api/series/?universe_id=10
+
+# Get all series where a creator has a specific role
+GET /api/series/?role_id=1
+
+# Get all series where a creator has any of several roles (comma-separated)
+GET /api/series/?role_id=1,2
 ```
 
 ---
@@ -1975,7 +1982,7 @@ For questions, issues, or feature requests:
 
 ### Version 1.5
 - Added `character_id`, `team_id`, and `universe_id` filters to Issue endpoint
-- Added `role_id` filter to Issue endpoint (accepts a single ID or multiple comma-separated IDs)
+- Added `role_id` filter to Issue and Series endpoints (accepts a single ID or multiple comma-separated IDs)
 - Added `imprint_id`, `character_id`, `team_id`, and `universe_id` filters to Series endpoint
 
 ### Version 1.4

--- a/comicsdb/filters/issue.py
+++ b/comicsdb/filters/issue.py
@@ -17,6 +17,10 @@ class IssueSeriesName(df.rest_framework.CharFilter):
         return super().filter(qs, value)
 
 
+class NumberInFilter(df.rest_framework.BaseInFilter, df.rest_framework.NumberFilter):
+    pass
+
+
 class IssueFilter(df.rest_framework.FilterSet):
     cover_year = df.rest_framework.NumberFilter(
         label="Cover Year", field_name="cover_date", lookup_expr="year"
@@ -88,6 +92,9 @@ class IssueFilter(df.rest_framework.FilterSet):
     )
     universe_id = df.rest_framework.NumberFilter(
         label="Universe Metron ID", field_name="universes__id", lookup_expr="exact", distinct=True
+    )
+    role_id = NumberInFilter(
+        label="Role Metron ID", field_name="credits__role__id", lookup_expr="in", distinct=True
     )
 
     class Meta:

--- a/comicsdb/filters/issue.py
+++ b/comicsdb/filters/issue.py
@@ -80,6 +80,15 @@ class IssueFilter(df.rest_framework.FilterSet):
     creator_id = df.rest_framework.NumberFilter(
         label="Creator Metron ID", field_name="creators__id", lookup_expr="exact", distinct=True
     )
+    character_id = df.rest_framework.NumberFilter(
+        label="Character Metron ID", field_name="characters__id", lookup_expr="exact", distinct=True
+    )
+    team_id = df.rest_framework.NumberFilter(
+        label="Team Metron ID", field_name="teams__id", lookup_expr="exact", distinct=True
+    )
+    universe_id = df.rest_framework.NumberFilter(
+        label="Universe Metron ID", field_name="universes__id", lookup_expr="exact", distinct=True
+    )
 
     class Meta:
         model = Issue

--- a/comicsdb/filters/series.py
+++ b/comicsdb/filters/series.py
@@ -25,6 +25,9 @@ class SeriesFilter(filters.FilterSet):
     publisher_id = filters.filters.NumberFilter(field_name="publisher__id", lookup_expr="exact")
     publisher_name = filters.CharFilter(field_name="publisher__name", lookup_expr="icontains")
     imprint_name = filters.CharFilter(field_name="imprint__name", lookup_expr="icontains")
+    imprint_id = filters.filters.NumberFilter(
+        label="Imprint Metron ID", field_name="imprint__id", lookup_expr="exact"
+    )
     series_type_id = filters.filters.NumberFilter(field_name="series_type__id", lookup_expr="exact")
     series_type = filters.CharFilter(field_name="series_type__name", lookup_expr="icontains")
     status = filters.ChoiceFilter(choices=Series.Status)
@@ -42,6 +45,24 @@ class SeriesFilter(filters.FilterSet):
     creator_id = filters.filters.NumberFilter(
         label="Creator Metron ID",
         field_name="issues__creators__id",
+        lookup_expr="exact",
+        distinct=True,
+    )
+    character_id = filters.filters.NumberFilter(
+        label="Character Metron ID",
+        field_name="issues__characters__id",
+        lookup_expr="exact",
+        distinct=True,
+    )
+    team_id = filters.filters.NumberFilter(
+        label="Team Metron ID",
+        field_name="issues__teams__id",
+        lookup_expr="exact",
+        distinct=True,
+    )
+    universe_id = filters.filters.NumberFilter(
+        label="Universe Metron ID",
+        field_name="issues__universes__id",
         lookup_expr="exact",
         distinct=True,
     )

--- a/comicsdb/filters/series.py
+++ b/comicsdb/filters/series.py
@@ -5,6 +5,7 @@ import django_filters as df
 from django.db.models import Q
 from django_filters import rest_framework as filters
 
+from comicsdb.filters.issue import NumberInFilter
 from comicsdb.models import Series
 
 
@@ -64,6 +65,12 @@ class SeriesFilter(filters.FilterSet):
         label="Universe Metron ID",
         field_name="issues__universes__id",
         lookup_expr="exact",
+        distinct=True,
+    )
+    role_id = NumberInFilter(
+        label="Role Metron ID",
+        field_name="issues__credits__role__id",
+        lookup_expr="in",
         distinct=True,
     )
 

--- a/tests/comicsdb/test_api_issue.py
+++ b/tests/comicsdb/test_api_issue.py
@@ -9,9 +9,11 @@ from rest_framework import status
 
 from comicsdb.models import Credits, Issue
 from comicsdb.models.arc import Arc
+from comicsdb.models.character import Character
 from comicsdb.models.creator import Creator
 from comicsdb.models.credits import Role
 from comicsdb.models.series import Series
+from comicsdb.models.team import Team
 from comicsdb.models.universe import Universe
 
 
@@ -255,5 +257,61 @@ def test_filter_by_creator_id_no_match(
     api_client_with_credentials, issue_with_arc: Issue, john_byrne: Creator
 ):
     resp = api_client_with_credentials.get(reverse("api:issue-list"), {"creator_id": john_byrne.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_character_id(
+    api_client_with_credentials, basic_issue: Issue, superman: Character
+):
+    basic_issue.characters.add(superman)
+    resp = api_client_with_credentials.get(reverse("api:issue-list"), {"character_id": superman.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == basic_issue.id
+
+
+def test_filter_by_character_id_no_match(
+    api_client_with_credentials, basic_issue: Issue, superman: Character
+):
+    resp = api_client_with_credentials.get(reverse("api:issue-list"), {"character_id": superman.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_team_id(api_client_with_credentials, basic_issue: Issue, teen_titans: Team):
+    basic_issue.teams.add(teen_titans)
+    resp = api_client_with_credentials.get(reverse("api:issue-list"), {"team_id": teen_titans.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == basic_issue.id
+
+
+def test_filter_by_team_id_no_match(
+    api_client_with_credentials, basic_issue: Issue, teen_titans: Team
+):
+    resp = api_client_with_credentials.get(reverse("api:issue-list"), {"team_id": teen_titans.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_universe_id(
+    api_client_with_credentials, basic_issue: Issue, earth_2_universe: Universe
+):
+    basic_issue.universes.add(earth_2_universe)
+    resp = api_client_with_credentials.get(
+        reverse("api:issue-list"), {"universe_id": earth_2_universe.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == basic_issue.id
+
+
+def test_filter_by_universe_id_no_match(
+    api_client_with_credentials, basic_issue: Issue, earth_2_universe: Universe
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:issue-list"), {"universe_id": earth_2_universe.id}
+    )
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["count"] == 0

--- a/tests/comicsdb/test_api_issue.py
+++ b/tests/comicsdb/test_api_issue.py
@@ -315,3 +315,34 @@ def test_filter_by_universe_id_no_match(
     )
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["count"] == 0
+
+
+def test_filter_by_role_id(
+    api_client_with_credentials, basic_issue: Issue, john_byrne: Creator, writer: Role
+):
+    credit = Credits.objects.create(issue=basic_issue, creator=john_byrne)
+    credit.role.add(writer)
+    resp = api_client_with_credentials.get(reverse("api:issue-list"), {"role_id": writer.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == basic_issue.id
+
+
+def test_filter_by_role_id_no_match(api_client_with_credentials, basic_issue: Issue, writer: Role):
+    resp = api_client_with_credentials.get(reverse("api:issue-list"), {"role_id": writer.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_multiple_role_ids(
+    api_client_with_credentials, basic_issue: Issue, john_byrne: Creator, writer: Role
+):
+    penciller = Role.objects.create(name="Penciller", notes="", order=30)
+    credit = Credits.objects.create(issue=basic_issue, creator=john_byrne)
+    credit.role.add(writer, penciller)
+    resp = api_client_with_credentials.get(
+        reverse("api:issue-list"), {"role_id": f"{writer.id},{penciller.id}"}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == basic_issue.id

--- a/tests/comicsdb/test_api_series.py
+++ b/tests/comicsdb/test_api_series.py
@@ -227,6 +227,45 @@ def test_filter_by_universe_id_no_match(
     assert resp.data["count"] == 0
 
 
+def test_filter_by_role_id(
+    api_client_with_credentials,
+    fc_series: Series,
+    basic_issue,
+    john_byrne: Creator,
+    writer: Role,
+):
+    credit = Credits.objects.create(issue=basic_issue, creator=john_byrne)
+    credit.role.add(writer)
+    resp = api_client_with_credentials.get(reverse("api:series-list"), {"role_id": writer.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == fc_series.id
+
+
+def test_filter_by_role_id_no_match(api_client_with_credentials, fc_series: Series, writer: Role):
+    resp = api_client_with_credentials.get(reverse("api:series-list"), {"role_id": writer.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_multiple_role_ids(
+    api_client_with_credentials,
+    fc_series: Series,
+    basic_issue,
+    john_byrne: Creator,
+    writer: Role,
+):
+    penciller = Role.objects.create(name="Penciller", notes="", order=30)
+    credit = Credits.objects.create(issue=basic_issue, creator=john_byrne)
+    credit.role.add(writer, penciller)
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"role_id": f"{writer.id},{penciller.id}"}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == fc_series.id
+
+
 def test_list_series_year_end_null(api_client_with_credentials, fc_series: Series):
     resp = api_client_with_credentials.get(reverse("api:series-list"))
     assert resp.status_code == status.HTTP_200_OK

--- a/tests/comicsdb/test_api_series.py
+++ b/tests/comicsdb/test_api_series.py
@@ -9,10 +9,14 @@ from rest_framework import status
 
 from api.v1_0.serializers import SeriesListSerializer
 from comicsdb.models import Credits, Series
+from comicsdb.models.character import Character
 from comicsdb.models.creator import Creator
 from comicsdb.models.credits import Role
+from comicsdb.models.imprint import Imprint
 from comicsdb.models.publisher import Publisher
 from comicsdb.models.series import SeriesType
+from comicsdb.models.team import Team
+from comicsdb.models.universe import Universe
 
 
 @pytest.fixture
@@ -136,6 +140,88 @@ def test_filter_by_creator_id_no_match(
 ):
     resp = api_client_with_credentials.get(
         reverse("api:series-list"), {"creator_id": john_byrne.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_imprint_id(
+    api_client_with_credentials, sandman_series: Series, vertigo_imprint: Imprint
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"imprint_id": vertigo_imprint.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == sandman_series.id
+
+
+def test_filter_by_imprint_id_no_match(
+    api_client_with_credentials, fc_series: Series, vertigo_imprint: Imprint
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"imprint_id": vertigo_imprint.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_character_id(
+    api_client_with_credentials, fc_series: Series, issue_with_arc, superman: Character
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"character_id": superman.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == fc_series.id
+
+
+def test_filter_by_character_id_no_match(
+    api_client_with_credentials, fc_series: Series, superman: Character
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"character_id": superman.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_team_id(
+    api_client_with_credentials, fc_series: Series, basic_issue, teen_titans: Team
+):
+    basic_issue.teams.add(teen_titans)
+    resp = api_client_with_credentials.get(reverse("api:series-list"), {"team_id": teen_titans.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == fc_series.id
+
+
+def test_filter_by_team_id_no_match(
+    api_client_with_credentials, fc_series: Series, teen_titans: Team
+):
+    resp = api_client_with_credentials.get(reverse("api:series-list"), {"team_id": teen_titans.id})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0
+
+
+def test_filter_by_universe_id(
+    api_client_with_credentials, fc_series: Series, basic_issue, earth_2_universe: Universe
+):
+    basic_issue.universes.add(earth_2_universe)
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"universe_id": earth_2_universe.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == fc_series.id
+
+
+def test_filter_by_universe_id_no_match(
+    api_client_with_credentials, fc_series: Series, earth_2_universe: Universe
+):
+    resp = api_client_with_credentials.get(
+        reverse("api:series-list"), {"universe_id": earth_2_universe.id}
     )
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["count"] == 0


### PR DESCRIPTION
## Summary

- Add `character_id`, `team_id`, `universe_id`, and `role_id` filters to `IssueFilter`
- Add `imprint_id`, `character_id`, `team_id`, `universe_id`, and `creator_id` filters to `SeriesFilter`
- `role_id` supports multiple comma-separated values (e.g. `?role_id=1,2,3`) via a `NumberInFilter` combining `BaseInFilter` and `NumberFilter`
- Series filters for character/team/universe traverse through issues (e.g. `issues__characters__id`), matching the existing `creator_id` pattern
