### PR TITLE
Add account self-deletion

### DIFF
--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -6,9 +6,11 @@ from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
 from users.forms import CustomUserChangeForm
+from users.models import CustomUser
 from users.views import SUSTAINED_DURATION, SUSTAINED_LIMIT, get_rate_limit_usage
 
-HTML_REDIRECT_CODE = 301
+HTML_REDIRECT_MOVED_PERMAMENTLY_CODE = 301
+HTTP_REDIRECT_FOUND_CODE = 302
 HTML_OK_CODE = 200
 
 
@@ -58,7 +60,7 @@ def test_profile_view_url_exists_at_desired_location(auto_login_user):
 def test_profile_view_pk_redirects_to_username(auto_login_user):
     client, user = auto_login_user()
     resp = client.get(f"/accounts/{user.pk}/")
-    assert resp.status_code == HTML_REDIRECT_CODE
+    assert resp.status_code == HTML_REDIRECT_MOVED_PERMAMENTLY_CODE
     assert resp.url == f"/accounts/{user.username}/"
 
 
@@ -188,3 +190,45 @@ def test_profile_view_excludes_rate_limit_for_other_profile(auto_login_user, cre
     resp = client.get(reverse("user-detail", kwargs={"username": other.username}))
     assert resp.status_code == HTML_OK_CODE
     assert "rate_limit" not in resp.context
+
+
+# --- delete_account view tests ---
+
+
+def test_delete_account_get_unauthenticated(client):
+    resp = client.get(reverse("delete_account"))
+    assert resp.status_code == HTTP_REDIRECT_FOUND_CODE
+    assert "/accounts/login/" in resp.url
+
+
+def test_delete_account_get_authenticated(auto_login_user):
+    client, _ = auto_login_user()
+    resp = client.get(reverse("delete_account"))
+    assert resp.status_code == HTML_OK_CODE
+    assertTemplateUsed(resp, "users/delete_account.html")
+
+
+def test_delete_account_post_unauthenticated(client, create_user):
+    user = create_user()
+    user_pk = user.pk
+    resp = client.post(reverse("delete_account"))
+    assert resp.status_code == HTTP_REDIRECT_FOUND_CODE
+    assert "/accounts/login/" in resp.url
+    assert CustomUser.objects.filter(pk=user_pk).exists()
+
+
+def test_delete_account_post_deletes_user(auto_login_user):
+    client, user = auto_login_user()
+    user_pk = user.pk
+    resp = client.post(reverse("delete_account"))
+    assert resp.status_code == HTTP_REDIRECT_FOUND_CODE
+    assert resp.url == reverse("home")
+    assert not CustomUser.objects.filter(pk=user_pk).exists()
+
+
+def test_delete_account_post_logs_out_user(auto_login_user):
+    client, _ = auto_login_user()
+    client.post(reverse("delete_account"))
+    resp = client.get(reverse("change_profile"))
+    assert resp.status_code == HTTP_REDIRECT_FOUND_CODE
+    assert "/accounts/login/" in resp.url

--- a/users/templates/users/customuser_detail.html
+++ b/users/templates/users/customuser_detail.html
@@ -30,6 +30,14 @@
                 </span>
                 <span>Change Password</span>
             </a>
+            <a class="button is-danger is-outlined"
+               href="{% url 'delete_account' %}"
+               title="Delete your account">
+                <span class="icon">
+                    <i class="fas fa-trash-alt"></i>
+                </span>
+                <span>Delete Account</span>
+            </a>
         </div>
     {% endif %}
     {# User Profile Card #}

--- a/users/templates/users/delete_account.html
+++ b/users/templates/users/delete_account.html
@@ -1,0 +1,51 @@
+{% extends parent_template|default:"base.html" %}
+{% block title %}
+    Delete Account - Metron
+{% endblock title %}
+{% block content %}
+    <div class="columns is-centered mt-5">
+        <div class="column is-half">
+            <div class="box">
+                <header class="has-text-centered mb-5">
+                    <span class="icon is-large has-text-danger">
+                        <i class="fas fa-exclamation-triangle fa-3x"></i>
+                    </span>
+                    <h1 class="title is-3 mt-4">Delete Your Account</h1>
+                    <p class="subtitle has-text-grey">This action cannot be undone</p>
+                </header>
+                <div class="notification is-danger is-light mb-5">
+                    <p class="has-text-weight-bold mb-2">Warning: Permanent deletion</p>
+                    <div class="content is-small">
+                        <ul>
+                            <li>Your account and all personal data will be permanently deleted</li>
+                            <li>Your reading list and collection data will be removed</li>
+                            <li>Database contributions (issues, creators, etc.) will remain but will no longer be attributed to you</li>
+                        </ul>
+                    </div>
+                </div>
+                <form method="post">
+                    {% csrf_token %}
+                    <div class="field is-grouped is-grouped-centered">
+                        <div class="control">
+                            <button class="button is-danger is-medium" type="submit">
+                                <span class="icon">
+                                    <i class="fas fa-trash-alt"></i>
+                                </span>
+                                <span>Delete My Account</span>
+                            </button>
+                        </div>
+                        <div class="control">
+                            <a class="button is-light is-medium"
+                               href="{% url 'user-detail' username=request.user.username %}">
+                                <span class="icon">
+                                    <i class="fas fa-times"></i>
+                                </span>
+                                <span>Cancel</span>
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/users/urls.py
+++ b/users/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     ),
     path("password/", views.ChangePasswordView.as_view(), name="change_password"),
     path("update/", views.change_profile, name="change_profile"),
+    path("delete/", views.delete_account, name="delete_account"),
     path("users/", views.UserList.as_view(), name="user-list"),
     path("search/", views.SearchUserList.as_view(), name="user-search"),
     path("<int:pk>/", views.user_profile_redirect, name="user-detail-redirect"),

--- a/users/views.py
+++ b/users/views.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 from django.contrib import messages
-from django.contrib.auth import login, update_session_auth_hash
+from django.contrib.auth import login, logout, update_session_auth_hash
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import PasswordChangeView
 from django.contrib.messages.views import SuccessMessageMixin
@@ -136,6 +136,18 @@ def change_profile(request):
     else:
         form = CustomUserChangeForm(instance=request.user)
     return render(request, "users/change_profile.html", {"form": form})
+
+
+def delete_account(request):
+    if not request.user.is_authenticated:
+        return redirect("login")
+    if request.method == "POST":
+        user = request.user
+        logout(request)
+        user.delete()
+        messages.success(request, "Your account has been deleted.")
+        return redirect("home")
+    return render(request, "users/delete_account.html")
 
 
 def user_profile_redirect(request, pk):


### PR DESCRIPTION
## Summary

- Adds a "Delete Account" button to the user profile page (visible only to the account owner)
- Clicking it leads to a confirmation page that warns the user what data will be lost
- On confirmation, the account is deleted, the session is terminated, and the user is redirected to the home page
- Database contributions (issues, creators, etc.) are preserved; personal data (collection, reading lists) is removed via cascade
