### PR TITLE
Add wish list toggle button and Actions dropdown to issue detail page

### DIFF
--- a/comicsdb/templates/comicsdb/arc_detail.html
+++ b/comicsdb/templates/comicsdb/arc_detail.html
@@ -48,30 +48,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'arc:update' arc.slug %}"
-                       title="Edit this story arc">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'arc:history' arc.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_arc %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'arc:delete' arc.slug %}"
-                           title="Delete this story arc">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="arc-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="arc-actions-menu"
+                                    hx-on:click="document.getElementById('arc-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="arc-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'arc:update' arc.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'arc:history' arc.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_arc %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'arc:delete' arc.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('arc-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Arc Image #}

--- a/comicsdb/templates/comicsdb/character_detail.html
+++ b/comicsdb/templates/comicsdb/character_detail.html
@@ -49,30 +49,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'character:update' character.slug %}"
-                       title="Edit this character">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'character:history' character.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_character %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'character:delete' character.slug %}"
-                           title="Delete this character">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="character-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="character-actions-menu"
+                                    hx-on:click="document.getElementById('character-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="character-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'character:update' character.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'character:history' character.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_character %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'character:delete' character.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('character-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Character Image #}

--- a/comicsdb/templates/comicsdb/creator_detail.html
+++ b/comicsdb/templates/comicsdb/creator_detail.html
@@ -49,30 +49,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'creator:update' creator.slug %}"
-                       title="Edit this creator">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'creator:history' creator.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_creator %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'creator:delete' creator.slug %}"
-                           title="Delete this creator">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="creator-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="creator-actions-menu"
+                                    hx-on:click="document.getElementById('creator-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="creator-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'creator:update' creator.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'creator:history' creator.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_creator %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'creator:delete' creator.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('creator-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Creator Image #}

--- a/comicsdb/templates/comicsdb/imprint_detail.html
+++ b/comicsdb/templates/comicsdb/imprint_detail.html
@@ -55,30 +55,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'imprint:update' imprint.slug %}"
-                       title="Edit this imprint">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'imprint:history' imprint.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_imprint %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'imprint:delete' imprint.slug %}"
-                           title="Delete this imprint">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="imprint-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="imprint-actions-menu"
+                                    hx-on:click="document.getElementById('imprint-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="imprint-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'imprint:update' imprint.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'imprint:history' imprint.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_imprint %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'imprint:delete' imprint.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 {% endif %}
             </div>
         </div>
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('imprint-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Imprint Logo #}

--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -76,6 +76,7 @@
         {% if user.is_authenticated %}
             <div class="level-right">
                 <div class="buttons">
+                    {% include "wish_list/partials/wish_list_button.html" with issue=issue on_wish_list=on_wish_list %}
                     <a class="button is-rounded is-primary"
                        href="{% url 'issue:create' %}"
                        title="Add a new issue">

--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -83,18 +83,6 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'issue:update' issue.slug %}"
-                       title="Edit this issue">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'issue:history' issue.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
                     {% if issue.series.series_type.name != "Trade Paperback" and issue.series.series_type.name != "Omnibus" and issue.series.series_type.name != "Hardcover" and issue.series.publisher.name != "DC Comics" and issue.series.publisher.name != "Marvel" %}
                         {% if navigation.previous_issue and not issue.credits_set.exists %}
                             <form method="post"
@@ -141,18 +129,51 @@
                             </button>
                         {% endif %}
                     {% endif %}
-                    {% if perms.comicsdb.delete_issue %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'issue:delete' issue.slug %}"
-                           title="Delete this issue">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="issue-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="issue-actions-menu"
+                                    hx-on:click="document.getElementById('issue-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="issue-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'issue:update' issue.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'issue:history' issue.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_issue %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'issue:delete' issue.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('issue-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Left Column - Covers #}

--- a/comicsdb/templates/comicsdb/publisher_detail.html
+++ b/comicsdb/templates/comicsdb/publisher_detail.html
@@ -55,30 +55,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'publisher:update' publisher.slug %}"
-                       title="Edit this publisher">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'publisher:history' publisher.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_publisher %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'publisher:delete' publisher.slug %}"
-                           title="Delete this publisher">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="publisher-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="publisher-actions-menu"
+                                    hx-on:click="document.getElementById('publisher-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="publisher-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'publisher:update' publisher.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'publisher:history' publisher.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_publisher %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'publisher:delete' publisher.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 {% endif %}
             </div>
         </div>
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('publisher-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Publisher Logo #}

--- a/comicsdb/templates/comicsdb/series_detail.html
+++ b/comicsdb/templates/comicsdb/series_detail.html
@@ -56,30 +56,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'series:update' series.slug %}"
-                       title="Edit this series">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'series:history' series.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_series %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'series:delete' series.slug %}"
-                           title="Delete this series">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="series-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="series-actions-menu"
+                                    hx-on:click="document.getElementById('series-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="series-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'series:update' series.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'series:history' series.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_series %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'series:delete' series.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 {% endif %}
             </div>
         </div>
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('series-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Series Cover #}

--- a/comicsdb/templates/comicsdb/series_detail.html
+++ b/comicsdb/templates/comicsdb/series_detail.html
@@ -49,6 +49,7 @@
                     <span>Issue List</span>
                 </a>
                 {% if user.is_authenticated %}
+                    {% include "pull_list/partials/pull_list_button.html" with series=series on_pull_list=on_pull_list %}
                     <a class="button is-rounded is-primary"
                        href="{% url 'series:create' %}"
                        title="Add a new series">

--- a/comicsdb/templates/comicsdb/team_detail.html
+++ b/comicsdb/templates/comicsdb/team_detail.html
@@ -49,30 +49,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'team:update' team.slug %}"
-                       title="Edit this team">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'team:history' team.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_team %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'team:delete' team.slug %}"
-                           title="Delete this team">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="team-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="team-actions-menu"
+                                    hx-on:click="document.getElementById('team-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="team-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'team:update' team.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'team:history' team.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_team %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'team:delete' team.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('team-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Team Image #}

--- a/comicsdb/templates/comicsdb/universe_detail.html
+++ b/comicsdb/templates/comicsdb/universe_detail.html
@@ -49,30 +49,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'universe:update' universe.slug %}"
-                       title="Edit this universe">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'universe:history' universe.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_universe %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'universe:delete' universe.slug %}"
-                           title="Delete this universe">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="universe-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="universe-actions-menu"
+                                    hx-on:click="document.getElementById('universe-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="universe-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'universe:update' universe.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'universe:history' universe.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_universe %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'universe:delete' universe.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('universe-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Universe Image #}

--- a/comicsdb/views/issue.py
+++ b/comicsdb/views/issue.py
@@ -27,6 +27,7 @@ from comicsdb.models.variant import Variant
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
 from comicsdb.views.mixins import LazyLoadMixin, SlugRedirectView
+from wish_list.models import WishListItem
 
 TOTAL_WEEKS_YEAR = 52
 
@@ -170,6 +171,12 @@ class IssueDetail(DetailView):
         context["universes_count"] = universes_count
         if universes_count > 0:
             context["universes"] = universes[:DETAIL_PAGINATE_BY]
+
+        if self.request.user.is_authenticated:
+            context["on_wish_list"] = WishListItem.objects.filter(
+                wish_list__user=self.request.user,
+                issue=issue,
+            ).exists()
 
         return context
 

--- a/comicsdb/views/series.py
+++ b/comicsdb/views/series.py
@@ -18,6 +18,7 @@ from comicsdb.views.mixins import (
     AttributionUpdateMixin,
     SlugRedirectView,
 )
+from pull_list.models import PullListSeries
 
 LOGGER = logging.getLogger(__name__)
 
@@ -129,6 +130,13 @@ class SeriesDetail(DetailView):
         }
         context["creators"] = creators
         context["characters"] = characters
+
+        if self.request.user.is_authenticated:
+            context["on_pull_list"] = PullListSeries.objects.filter(
+                pull_list__user=self.request.user,
+                series=series,
+            ).exists()
+
         return context
 
 

--- a/pull_list/templates/pull_list/partials/pull_list_button.html
+++ b/pull_list/templates/pull_list/partials/pull_list_button.html
@@ -1,0 +1,11 @@
+<button id="pull-list-btn"
+        class="button is-rounded {% if on_pull_list %}is-info{% else %}is-light{% endif %}"
+        hx-post="{% url 'pull-list:toggle' series.slug %}"
+        hx-target="#pull-list-btn"
+        hx-swap="outerHTML"
+        title="{% if on_pull_list %}Remove from pull list{% else %}Add to pull list{% endif %}">
+    <span class="icon is-small">
+        <i class="{% if on_pull_list %}fas{% else %}far{% endif %} fa-bookmark" aria-hidden="true"></i>
+    </span>
+    <span>Pull List</span>
+</button>

--- a/pull_list/urls.py
+++ b/pull_list/urls.py
@@ -1,10 +1,15 @@
 from django.urls import path
 
-from pull_list.views import PullListDetailView, RemoveSeriesFromPullListView
+from pull_list.views import (
+    PullListDetailView,
+    RemoveSeriesFromPullListView,
+    toggle_pull_list_series,
+)
 
 app_name = "pull-list"
 
 urlpatterns = [
     path("", PullListDetailView.as_view(), name="detail"),
     path("remove/<int:series_pk>/", RemoveSeriesFromPullListView.as_view(), name="remove-series"),
+    path("toggle/<slug:slug>/", toggle_pull_list_series, name="toggle"),
 ]

--- a/pull_list/views.py
+++ b/pull_list/views.py
@@ -1,11 +1,14 @@
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 from django.views.generic import DeleteView, FormView
 
 from comicsdb.models.issue import Issue
+from comicsdb.models.series import Series
 from pull_list.forms import AddSeriesToPullListForm
 from pull_list.models import PullList, PullListSeries
 
@@ -77,3 +80,23 @@ class RemoveSeriesFromPullListView(LoginRequiredMixin, UserPassesTestMixin, Dele
         result = super().form_valid(form)
         messages.success(self.request, f"Removed {series_name} from your pull list.")
         return result
+
+
+@login_required
+@require_POST
+def toggle_pull_list_series(request, slug):
+    series = get_object_or_404(Series, slug=slug)
+    pull_list, _ = PullList.objects.get_or_create(user=request.user)
+    pull_list_series, created = PullListSeries.objects.get_or_create(
+        pull_list=pull_list, series=series
+    )
+    if not created:
+        pull_list_series.delete()
+        on_pull_list = False
+    else:
+        on_pull_list = True
+    return render(
+        request,
+        "pull_list/partials/pull_list_button.html",
+        {"series": series, "on_pull_list": on_pull_list},
+    )

--- a/tests/comicsdb/test_issue_views.py
+++ b/tests/comicsdb/test_issue_views.py
@@ -10,6 +10,7 @@ from comicsdb.models.credits import Role
 from comicsdb.models.issue import Issue
 from comicsdb.models.publisher import Publisher
 from comicsdb.models.series import Series, SeriesType
+from wish_list.models import WishList, WishListItem
 
 HTML_OK_CODE = 200
 HTML_REDIRECT_CODE = 302
@@ -29,6 +30,22 @@ def test_issue_redirect(basic_issue, auto_login_user):
     client, _ = auto_login_user()
     resp = client.get(f"/issue/{basic_issue.pk}/")
     assert resp.status_code == HTML_REDIRECT_CODE
+
+
+def test_issue_detail_on_wish_list_false_when_not_on_list(basic_issue, auto_login_user):
+    client, _ = auto_login_user()
+    resp = client.get(f"/issue/{basic_issue.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["on_wish_list"] is False
+
+
+def test_issue_detail_on_wish_list_true_when_on_list(basic_issue, auto_login_user):
+    client, user = auto_login_user()
+    wish_list = WishList.objects.create(user=user)
+    WishListItem.objects.create(wish_list=wish_list, issue=basic_issue)
+    resp = client.get(f"/issue/{basic_issue.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["on_wish_list"] is True
 
 
 # Issue Search

--- a/tests/comicsdb/test_series_views.py
+++ b/tests/comicsdb/test_series_views.py
@@ -5,6 +5,7 @@ from pytest_django.asserts import assertTemplateUsed
 from comicsdb.forms.series import SeriesForm
 from comicsdb.models import Genre, Imprint, Publisher, Series, SeriesType
 from comicsdb.models.attribution import Attribution
+from pull_list.models import PullList, PullListSeries
 
 HTML_OK_CODE = 200
 HTML_REDIRECT_CODE = 302
@@ -43,6 +44,22 @@ def test_series_redirect(sandman_series, auto_login_user):
     client, _ = auto_login_user()
     resp = client.get(f"/series/{sandman_series.pk}/")
     assert resp.status_code == HTML_REDIRECT_CODE
+
+
+def test_series_detail_on_pull_list_false_when_not_on_list(sandman_series, auto_login_user):
+    client, _ = auto_login_user()
+    resp = client.get(f"/series/{sandman_series.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["on_pull_list"] is False
+
+
+def test_series_detail_on_pull_list_true_when_on_list(sandman_series, auto_login_user):
+    client, user = auto_login_user()
+    pull_list = PullList.objects.create(user=user)
+    PullListSeries.objects.create(pull_list=pull_list, series=sandman_series)
+    resp = client.get(f"/series/{sandman_series.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["on_pull_list"] is True
 
 
 def test_series_search_view_url_exists_at_desired_location(auto_login_user):

--- a/tests/pull_list/test_views.py
+++ b/tests/pull_list/test_views.py
@@ -5,6 +5,55 @@ from django.urls import reverse
 from pull_list.models import PullList, PullListSeries
 
 
+# Toggle view
+def test_toggle_requires_login(client, pull_list_series):
+    resp = client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 302
+    assert "/accounts/login" in resp["Location"]
+
+
+def test_toggle_get_not_allowed(client, pull_list_user, test_password, pull_list_series):
+    client.login(username=pull_list_user.username, password=test_password)
+    resp = client.get(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 405
+
+
+def test_toggle_adds_series_to_pull_list(client, pull_list_user, test_password, pull_list_series):
+    client.login(username=pull_list_user.username, password=test_password)
+    resp = client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 200
+    assert PullListSeries.objects.filter(
+        pull_list__user=pull_list_user, series=pull_list_series
+    ).exists()
+
+
+def test_toggle_removes_series_from_pull_list(
+    client, pull_list_user, test_password, pull_list_with_series, pull_list_series
+):
+    client.login(username=pull_list_user.username, password=test_password)
+    resp = client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 200
+    assert not PullListSeries.objects.filter(
+        pull_list__user=pull_list_user, series=pull_list_series
+    ).exists()
+
+
+def test_toggle_response_contains_button(client, pull_list_user, test_password, pull_list_series):
+    client.login(username=pull_list_user.username, password=test_password)
+    resp = client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 200
+    assert b"pull-list-btn" in resp.content
+
+
+def test_toggle_creates_pull_list_if_missing(
+    client, pull_list_user, test_password, pull_list_series
+):
+    client.login(username=pull_list_user.username, password=test_password)
+    assert not PullList.objects.filter(user=pull_list_user).exists()
+    client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert PullList.objects.filter(user=pull_list_user).exists()
+
+
 # Detail view — authentication
 def test_detail_view_requires_login(client):
     resp = client.get(reverse("pull-list:detail"))

--- a/tests/wish_list/test_views.py
+++ b/tests/wish_list/test_views.py
@@ -6,6 +6,55 @@ from user_collection.models import CollectionItem
 from wish_list.models import WishList, WishListItem
 
 
+# Toggle view
+def test_toggle_requires_login(client, wish_list_issue):
+    resp = client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 302
+    assert "/accounts/login" in resp["Location"]
+
+
+def test_toggle_get_not_allowed(client, wish_list_user, test_password, wish_list_issue):
+    client.login(username=wish_list_user.username, password=test_password)
+    resp = client.get(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 405
+
+
+def test_toggle_adds_issue_to_wish_list(client, wish_list_user, test_password, wish_list_issue):
+    client.login(username=wish_list_user.username, password=test_password)
+    resp = client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 200
+    assert WishListItem.objects.filter(
+        wish_list__user=wish_list_user, issue=wish_list_issue
+    ).exists()
+
+
+def test_toggle_removes_issue_from_wish_list(
+    client, wish_list_user, test_password, wish_list_item, wish_list_issue
+):
+    client.login(username=wish_list_user.username, password=test_password)
+    resp = client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 200
+    assert not WishListItem.objects.filter(
+        wish_list__user=wish_list_user, issue=wish_list_issue
+    ).exists()
+
+
+def test_toggle_response_contains_button(client, wish_list_user, test_password, wish_list_issue):
+    client.login(username=wish_list_user.username, password=test_password)
+    resp = client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 200
+    assert b"wish-list-btn" in resp.content
+
+
+def test_toggle_creates_wish_list_if_missing(
+    client, wish_list_user, test_password, wish_list_issue
+):
+    client.login(username=wish_list_user.username, password=test_password)
+    assert not WishList.objects.filter(user=wish_list_user).exists()
+    client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert WishList.objects.filter(user=wish_list_user).exists()
+
+
 # Detail view — authentication
 def test_detail_view_requires_login(client):
     resp = client.get(reverse("wish-list:detail"))
@@ -21,7 +70,7 @@ def test_detail_view_authenticated_creates_wish_list(client, wish_list_user, tes
     assert WishList.objects.filter(user=wish_list_user).exists()
 
 
-def test_detail_view_shows_items(client, wish_list_user, test_password, wish_list_item, wish_list):
+def test_detail_view_shows_items(client, wish_list_user, test_password, wish_list_item):
     client.login(username=wish_list_user.username, password=test_password)
     resp = client.get(reverse("wish-list:detail"))
     assert resp.status_code == 200
@@ -53,9 +102,7 @@ def test_add_duplicate_item_shows_info(
 
 
 # Item update view
-def test_item_update_requires_owner(
-    client, other_wish_list_user, test_password, wish_list_item, wish_list_issue
-):
+def test_item_update_requires_owner(client, other_wish_list_user, test_password, wish_list_item):
     client.login(username=other_wish_list_user.username, password=test_password)
     resp = client.get(reverse("wish-list:item-update", kwargs={"pk": wish_list_item.pk}))
     assert resp.status_code == 403

--- a/wish_list/templates/wish_list/partials/wish_list_button.html
+++ b/wish_list/templates/wish_list/partials/wish_list_button.html
@@ -1,0 +1,11 @@
+<button id="wish-list-btn"
+        class="button is-rounded {% if on_wish_list %}is-warning{% else %}is-light{% endif %}"
+        hx-post="{% url 'wish-list:toggle' issue.slug %}"
+        hx-target="#wish-list-btn"
+        hx-swap="outerHTML"
+        title="{% if on_wish_list %}Remove from wish list{% else %}Add to wish list{% endif %}">
+    <span class="icon is-small">
+        <i class="{% if on_wish_list %}fas{% else %}far{% endif %} fa-bookmark" aria-hidden="true"></i>
+    </span>
+    <span>Wish List</span>
+</button>

--- a/wish_list/urls.py
+++ b/wish_list/urls.py
@@ -5,6 +5,7 @@ from wish_list.views import (
     WishListDetailView,
     WishListItemDeleteView,
     WishListItemUpdateView,
+    toggle_wish_list_item,
 )
 
 app_name = "wish-list"
@@ -14,4 +15,5 @@ urlpatterns = [
     path("item/<int:pk>/update/", WishListItemUpdateView.as_view(), name="item-update"),
     path("item/<int:pk>/delete/", WishListItemDeleteView.as_view(), name="item-delete"),
     path("item/<int:pk>/acquire/", AcquireWishListItemView.as_view(), name="item-acquire"),
+    path("toggle/<slug:slug>/", toggle_wish_list_item, name="toggle"),
 ]

--- a/wish_list/views.py
+++ b/wish_list/views.py
@@ -1,9 +1,12 @@
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
+from django.views.decorators.http import require_POST
 from django.views.generic import DeleteView, FormView, UpdateView
 
+from comicsdb.models.issue import Issue
 from user_collection.models import CollectionItem
 from wish_list.forms import AcquireWishListItemForm, WishListItemForm
 from wish_list.models import WishList, WishListItem
@@ -117,3 +120,21 @@ class AcquireWishListItemView(LoginRequiredMixin, UserPassesTestMixin, FormView)
         context = super().get_context_data(**kwargs)
         context["item"] = self.wish_list_item
         return context
+
+
+@login_required
+@require_POST
+def toggle_wish_list_item(request, slug):
+    issue = get_object_or_404(Issue, slug=slug)
+    wish_list, _ = WishList.objects.get_or_create(user=request.user)
+    item, created = WishListItem.objects.get_or_create(wish_list=wish_list, issue=issue)
+    if not created:
+        item.delete()
+        on_wish_list = False
+    else:
+        on_wish_list = True
+    return render(
+        request,
+        "wish_list/partials/wish_list_button.html",
+        {"issue": issue, "on_wish_list": on_wish_list},
+    )


### PR DESCRIPTION
## Summary

- Adds an HTMX-powered wish list toggle button to the issue detail nav bar; clicking it adds or removes the issue from the user's wish list without a
  full page reload, with visual feedback (filled/outlined bookmark icon)
- Groups Edit, History, and Delete into an Actions dropdown to reduce nav bar clutter; Delete is separated by a divider and only visible to users with
  delete permissions
- Adds tests for the toggle view (auth, GET rejection, add, remove, auto-create wish list) and for the `on_wish_list` context variable on the issue detail view