### PR TITLE
Site UI refresh: navbar reorganization, home page redesign, and HTMX detail page actions

### DIFF
--- a/comicsdb/templates/comicsdb/arc_detail.html
+++ b/comicsdb/templates/comicsdb/arc_detail.html
@@ -48,30 +48,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'arc:update' arc.slug %}"
-                       title="Edit this story arc">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'arc:history' arc.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_arc %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'arc:delete' arc.slug %}"
-                           title="Delete this story arc">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="arc-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="arc-actions-menu"
+                                    hx-on:click="document.getElementById('arc-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="arc-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'arc:update' arc.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'arc:history' arc.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_arc %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'arc:delete' arc.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('arc-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Arc Image #}

--- a/comicsdb/templates/comicsdb/character_detail.html
+++ b/comicsdb/templates/comicsdb/character_detail.html
@@ -49,30 +49,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'character:update' character.slug %}"
-                       title="Edit this character">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'character:history' character.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_character %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'character:delete' character.slug %}"
-                           title="Delete this character">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="character-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="character-actions-menu"
+                                    hx-on:click="document.getElementById('character-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="character-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'character:update' character.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'character:history' character.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_character %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'character:delete' character.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('character-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Character Image #}

--- a/comicsdb/templates/comicsdb/creator_detail.html
+++ b/comicsdb/templates/comicsdb/creator_detail.html
@@ -49,30 +49,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'creator:update' creator.slug %}"
-                       title="Edit this creator">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'creator:history' creator.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_creator %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'creator:delete' creator.slug %}"
-                           title="Delete this creator">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="creator-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="creator-actions-menu"
+                                    hx-on:click="document.getElementById('creator-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="creator-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'creator:update' creator.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'creator:history' creator.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_creator %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'creator:delete' creator.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('creator-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Creator Image #}

--- a/comicsdb/templates/comicsdb/home.html
+++ b/comicsdb/templates/comicsdb/home.html
@@ -29,130 +29,116 @@
             {% endfor %}
         </div>
     {% endif %}
-{% endcache %}
-{# Hero Header #}
-<section class="hero is-small is-link">
-    <div class="hero-body">
-        <div class="container has-text-centered">
-            <h1 class="title is-1">Metron</h1>
-            <p class="subtitle is-3">Comic Book Database</p>
-            <div class="columns is-mobile mt-5">
-                <div class="column has-text-centered">
-                    <div>
-                        <span class="icon is-large" aria-hidden="true">
-                            <i class="fas fa-database fa-2x"></i>
-                        </span>
-                        <p class="heading">Database</p>
+    {% endcache %}
+    {# Hero Header #}
+    <section class="hero is-small is-link">
+        <div class="hero-body">
+            <div class="container has-text-centered">
+                <h1 class="title is-1">Metron</h1>
+                <p class="subtitle is-3">Comic Book Database</p>
+                <div class="columns is-mobile mt-5">
+                    <div class="column has-text-centered">
+                        <div>
+                            <span class="icon is-large" aria-hidden="true">
+                                <i class="fas fa-database fa-2x"></i>
+                            </span>
+                            <p class="heading">Database</p>
+                        </div>
                     </div>
-                </div>
-                <div class="column has-text-centered">
-                    <div>
-                        <span class="icon is-large" aria-hidden="true">
-                            <i class="fas fa-satellite-dish fa-2x"></i>
-                        </span>
-                        <p class="heading">REST API</p>
+                    <div class="column has-text-centered">
+                        <div>
+                            <span class="icon is-large" aria-hidden="true">
+                                <i class="fas fa-satellite-dish fa-2x"></i>
+                            </span>
+                            <p class="heading">REST API</p>
+                        </div>
                     </div>
-                </div>
-                <div class="column has-text-centered">
-                    <div>
-                        <span class="icon is-large" aria-hidden="true">
-                            <i class="fas fa-users fa-2x"></i>
-                        </span>
-                        <p class="heading">Community</p>
+                    <div class="column has-text-centered">
+                        <div>
+                            <span class="icon is-large" aria-hidden="true">
+                                <i class="fas fa-users fa-2x"></i>
+                            </span>
+                            <p class="heading">Community</p>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-</section>
-{# Information Cards #}
-<section class="section">
-    <div class="container">
-        <div class="columns is-multiline is-mobile">
-            <div class="column is-12-mobile is-12-tablet is-full-desktop">
-                {# What is Metron #}
-                <article class="box has-background-link has-text-link-invert is-height-100">
-                    <h2 class="title has-text-link-invert">What is Metron?</h2>
-                    <div class="content">
-                        <p>
-                            <strong>Metron</strong> is a community-based site whose goal is to build an open database
-                            with a <a href="https://en.wikipedia.org/wiki/Representational_state_transfer"
+    </section>
+    {# What is Metron #}
+    <section id="about" class="section">
+        <div class="container">
+            <h2 class="is-size-2">What is Metron?</h2>
+            <div class="content mt-4">
+                <p>
+                    <strong>Metron</strong> is a community-based site whose goal is to build an open database
+                    with a <a href="https://en.wikipedia.org/wiki/Representational_state_transfer"
     target="_blank"
-    rel="noopener noreferrer"
-    class="has-text-link-invert">REST</a> API for comic books.
-                        </p>
-                        <p>
-                            Originally, when this project was created, the only comic book database that provided a REST API for users was
-                            <a href="https://comicvine.gamespot.com/"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="has-text-link-invert">Comic Vine</a>. Unfortunately, it's a corporately-owned service and
-                            the community that uses it has no control over the resources provided to maintain it or ensure its
-                            continued accessibility. This project was started to create an alternative.
-                        </p>
-                        <p>
-                            <strong>Note:</strong> Recently, the <a href="https://www.comics.org/"
+    rel="noopener noreferrer">REST</a> API for comic books.
+                </p>
+                <p>
+                    Originally, when this project was created, the only comic book database that provided a REST API for users was
+                    <a href="https://comicvine.gamespot.com/"
+                       target="_blank"
+                       rel="noopener noreferrer">Comic Vine</a>. Unfortunately, it's a corporately-owned service and
+                    the community that uses it has no control over the resources provided to maintain it or ensure its
+                    continued accessibility. This project was started to create an alternative.
+                </p>
+                <p>
+                    <strong>Note:</strong> Recently, the <a href="https://www.comics.org/"
     target="_blank"
-    rel="noopener noreferrer"
-    class="has-text-link-invert">Grand Comics Database</a> created an
-                            <a href="https://github.com/GrandComicsDatabase/gcd-django/wiki/API"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="has-text-link-invert">API</a>, which you may wish to explore as an alternative.
-                        </p>
-                    </div>
-                </article>
+    rel="noopener noreferrer">Grand Comics Database</a> created an
+                    <a href="https://github.com/GrandComicsDatabase/gcd-django/wiki/API"
+                       target="_blank"
+                       rel="noopener noreferrer">API</a>, which you may wish to explore as an alternative.
+                </p>
             </div>
-            <div class="column is-12-mobile is-6-tablet">
-                {# Using the REST API #}
-                <article class="box has-background-warning has-text-warning-invert is-height-100">
-                    <h2 class="title has-text-warning-invert">Using the REST API</h2>
-                    <div class="content">
+        </div>
+    </section>
+    {# REST API + Reading Lists & Collections #}
+    <section id="features" class="section has-background-section-alt">
+        <div class="container">
+            <div class="columns is-desktop">
+                <div class="column is-half-desktop">
+                    <h2 class="is-size-2">Using the REST API</h2>
+                    <div class="content mt-4">
                         <p>
                             If you want to use data from Metron, there is a <a href="https://www.python.org/"
     target="_blank"
-    rel="noopener noreferrer"
-    class="has-text-warning-invert">Python</a> wrapper
-                            called <a href="https://github.com/Metron-Project/mokkari"
+    rel="noopener noreferrer">Python</a> wrapper called
+                            <a href="https://github.com/Metron-Project/mokkari"
     target="_blank"
-    rel="noopener noreferrer"
-    class="has-text-warning-invert">Mokkari</a> to make it easy to use the API.
+    rel="noopener noreferrer">Mokkari</a> to make it easy to use the API.
                         </p>
                         <p>Want to tag your comic archives with metadata from Metron? You can use these projects:</p>
                         <ul>
                             <li>
                                 <a href="https://github.com/Metron-Project/metron-tagger"
                                    target="_blank"
-                                   rel="noopener noreferrer"
-                                   class="has-text-warning-invert">Metron-Tagger</a>
+                                   rel="noopener noreferrer">Metron-Tagger</a>
                             </li>
                             <li>
                                 <a href="https://github.com/Buried-In-Code/Perdoo"
                                    target="_blank"
-                                   rel="noopener noreferrer"
-                                   class="has-text-warning-invert">Perdoo</a>
+                                   rel="noopener noreferrer">Perdoo</a>
                             </li>
                             <li>
                                 <s><a href="https://github.com/comictagger/comictagger/issues/783"
    target="_blank"
-   rel="noopener noreferrer"
-   class="has-text-warning-invert">Comic Tagger</a></s> (No longer supported)
+   rel="noopener noreferrer">Comic Tagger</a></s> (No longer supported)
                             </li>
                         </ul>
                         <p>
                             For more information on the API, please refer to the
-                            <a href="{% url 'wiki:root' %}" class="has-text-warning-invert">Wiki</a>.
+                            <a href="{% url 'wiki:root' %}">Wiki</a>.
                         </p>
                     </div>
-                </article>
-            </div>
-            <div class="column is-12-mobile is-6-tablet">
-                {# Reading Lists & Collections #}
-                <article class="box has-background-info has-text-info-invert is-height-100">
-                    <h2 class="title has-text-info-invert">Reading Lists & Collections</h2>
-                    <div class="content">
+                </div>
+                <div class="column is-half-desktop">
+                    <h2 class="is-size-2">Reading Lists & Collections</h2>
+                    <div class="content mt-4">
                         <p>
-                            Metron now supports <strong>Reading Lists</strong> and <strong>Collections</strong> to help you organize and track your comics!
+                            Metron supports <strong>Reading Lists</strong> and <strong>Collections</strong> to help you organize and track your comics!
                         </p>
                         <p>
                             <strong>Reading Lists</strong> allow you to create custom lists of issues you want to read, mark your progress, and share your reading order with others.
@@ -161,99 +147,90 @@
                             <strong>Collections</strong> let you catalog and organize the comics you own, making it easy to keep track of your personal library. Track grades, purchase history, reading status, and rate your comics.
                         </p>
                         <p>
-                            <strong>Quick Scrobble:</strong> Mark issues as read instantly via our API - useful for comic servers!
+                            <strong>Quick Scrobble:</strong> Mark issues as read instantly via our API — useful for comic servers!
                         </p>
                         <p>Sign up for an account to start creating your own reading lists and collections today!</p>
                     </div>
-                </article>
+                </div>
             </div>
-            <div class="column is-12-mobile is-6-tablet">
-                {# Want to Contribute #}
-                <article class="box has-background-primary has-text-primary-invert is-height-100">
-                    <h2 class="title has-text-primary-invert">Want to Contribute?</h2>
-                    <div class="content">
+        </div>
+    </section>
+    {# Timeline #}
+    <section id="timeline" class="section has-text-centered">
+        <div class="container">
+            <article class="box">
+                <header class="title">Interactive timeline</header>
+                <div class="mini-timeline">
+                    <i class="fa fa-asterisk"></i>
+                    <i class="fa fa-code"></i>
+                    <i class="fab fa-lg fa-python"></i>
+                    <i class="fa fa-sm fa-terminal"></i>
+                    <i class="fa fa-bug"></i>
+                </div>
+                <p class="subtitle">
+                    Discover the history of our community, and learn about the events that made our community what it is today.
+                </p>
+                <div class="buttons are-medium is-centered">
+                    <a href="{% url 'timeline:timeline' %}" class="button is-primary">
+                        <span>Check it out!</span>
+                        <span class="icon">
+                            <i class="fas fa-arrow-right"></i>
+                        </span>
+                    </a>
+                </div>
+            </article>
+        </div>
+    </section>
+    {# Contribute + Questions #}
+    <section id="community" class="section has-background-section-alt">
+        <div class="container">
+            <div class="columns is-desktop">
+                <div class="column is-half-desktop">
+                    <h2 class="is-size-2">Want to Contribute?</h2>
+                    <div class="content mt-4">
                         <p>
                             If you would like to donate to help cover server and development costs, you can support us through
                             <a href="https://opencollective.com/metron"
                                target="_blank"
-                               rel="noopener noreferrer"
-                               class="has-text-primary-invert">OpenCollective</a>.
+                               rel="noopener noreferrer">OpenCollective</a>.
                         </p>
                         <p>
                             If you want to add information to Metron, sign up for an account and read the
-                            <a href="{% url 'wiki:root' %}" class="has-text-primary-invert">Wiki</a>
-                            before starting.
+                            <a href="{% url 'wiki:root' %}">Wiki</a> before starting.
                         </p>
                         <p>
                             Want to help with the technical side of Metron? Metron is built with
                             <a href="https://www.djangoproject.com/"
                                target="_blank"
-                               rel="noopener noreferrer"
-                               class="has-text-primary-invert">Django</a>. If you have knowledge of Python and Django, head over
-                            to <a href="https://github.com/Metron-Project/metron"
+                               rel="noopener noreferrer">Django</a>. If you have knowledge of Python and Django, head over to
+                            <a href="https://github.com/Metron-Project/metron"
     target="_blank"
-    rel="noopener noreferrer"
-    class="has-text-primary-invert">GitHub</a> to check out the site's code.
+    rel="noopener noreferrer">GitHub</a> to check out the site's code.
                         </p>
                     </div>
-                </article>
-            </div>
-            <div class="column is-12-mobile is-6-tablet">
-                {# Questions #}
-                <article class="box has-background-danger has-text-danger-invert is-height-100">
-                    <h2 class="title has-text-danger-invert">Questions?</h2>
-                    <div class="content">
+                </div>
+                <div class="column is-half-desktop">
+                    <h2 class="is-size-2">Questions?</h2>
+                    <div class="content mt-4">
                         <p>Have questions not covered here or suggestions? Feel free to contact us at any of these places:</p>
                         <ul>
                             <li>
                                 <a href="https://matrix.to/#/#metrondb:matrix.org"
                                    target="_blank"
-                                   rel="noopener noreferrer"
-                                   class="has-text-danger-invert">Matrix Chat</a>
+                                   rel="noopener noreferrer">Matrix Chat</a>
                             </li>
                             <li>
                                 <a href="https://github.com/Metron-Project/metron/discussions"
                                    target="_blank"
-                                   rel="noopener noreferrer"
-                                   class="has-text-danger-invert">GitHub Discussions</a>
+                                   rel="noopener noreferrer">GitHub Discussions</a>
                             </li>
                             <li>
-                                <a href="mailto:admin@metron.cloud" class="has-text-danger-invert">Email Site Admin</a>
+                                <a href="mailto:admin@metron.cloud">Email Site Admin</a>
                             </li>
                         </ul>
                     </div>
-                </article>
+                </div>
             </div>
         </div>
-    </div>
-</section>
-{# Timeline #}
-<section id="timeline" class="section has-text-centered">
-    <article class="box">
-
-        <header class="title">Interactive timeline</header>
-
-        <div class="mini-timeline">
-            <i class="fa fa-asterisk"></i>
-            <i class="fa fa-code"></i>
-            <i class="fab fa-lg fa-python"></i>
-            <i class="fa fa-sm fa-terminal"></i>
-            <i class="fa fa-bug"></i>
-        </div>
-
-        <p class="subtitle">
-            Discover the history of our community, and learn about the events that made our community what it is today.
-        </p>
-
-        <div class="buttons are-large is-centered">
-            <a href="{% url 'timeline:timeline' %}" class="button is-primary">
-                <span>Check it out!</span>
-                <span class="icon">
-                    <i class="fas fa-arrow-right"></i>
-                </span>
-            </a>
-        </div>
-
-    </article>
-</section>
+    </section>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/home.html
+++ b/comicsdb/templates/comicsdb/home.html
@@ -149,11 +149,35 @@
                         <p>
                             <strong>Quick Scrobble:</strong> Mark issues as read instantly via our API — useful for comic servers!
                         </p>
-                        <p>Sign up for an account to start creating your own reading lists and collections today!</p>
                     </div>
                 </div>
             </div>
         </div>
+        <div class="columns is-desktop mt-5">
+            <div class="column is-half-desktop">
+                <h2 class="is-size-2">Wish List</h2>
+                <div class="content mt-4">
+                    <p>
+                        Keep track of issues you want to acquire with your personal <strong>Wish List</strong>.
+                        Add issues you're hunting for so you never lose track of them while shopping or trading.
+                    </p>
+                    <p>Wish list management is also available via the REST API at <code>/api/wish_list/</code>.</p>
+                </div>
+            </div>
+            <div class="column is-half-desktop">
+                <h2 class="is-size-2">Pull List</h2>
+                <div class="content mt-4">
+                    <p>
+                        Follow the series you love with your <strong>Pull List</strong>. Add ongoing titles
+                        you're collecting to get a consolidated view of everything you're currently following.
+                    </p>
+                    <p>Pull list management is also available via the REST API at <code>/api/pull_list/</code>.</p>
+                </div>
+            </div>
+        </div>
+        <p class="mt-5">
+            <a href="{% url 'signup' %}">Create an account</a> to start using these features today!
+        </p>
     </section>
     {# Timeline #}
     <section id="timeline" class="section has-text-centered">

--- a/comicsdb/templates/comicsdb/imprint_detail.html
+++ b/comicsdb/templates/comicsdb/imprint_detail.html
@@ -55,30 +55,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'imprint:update' imprint.slug %}"
-                       title="Edit this imprint">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'imprint:history' imprint.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_imprint %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'imprint:delete' imprint.slug %}"
-                           title="Delete this imprint">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="imprint-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="imprint-actions-menu"
+                                    hx-on:click="document.getElementById('imprint-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="imprint-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'imprint:update' imprint.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'imprint:history' imprint.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_imprint %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'imprint:delete' imprint.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 {% endif %}
             </div>
         </div>
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('imprint-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Imprint Logo #}

--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -76,23 +76,12 @@
         {% if user.is_authenticated %}
             <div class="level-right">
                 <div class="buttons">
+                    {% include "wish_list/partials/wish_list_button.html" with issue=issue on_wish_list=on_wish_list %}
                     <a class="button is-rounded is-primary"
                        href="{% url 'issue:create' %}"
                        title="Add a new issue">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
-                    </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'issue:update' issue.slug %}"
-                       title="Edit this issue">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'issue:history' issue.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
                     </a>
                     {% if issue.series.series_type.name != "Trade Paperback" and issue.series.series_type.name != "Omnibus" and issue.series.series_type.name != "Hardcover" and issue.series.publisher.name != "DC Comics" and issue.series.publisher.name != "Marvel" %}
                         {% if navigation.previous_issue and not issue.credits_set.exists %}
@@ -140,18 +129,51 @@
                             </button>
                         {% endif %}
                     {% endif %}
-                    {% if perms.comicsdb.delete_issue %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'issue:delete' issue.slug %}"
-                           title="Delete this issue">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="issue-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="issue-actions-menu"
+                                    hx-on:click="document.getElementById('issue-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="issue-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'issue:update' issue.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'issue:history' issue.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_issue %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'issue:delete' issue.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('issue-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Left Column - Covers #}

--- a/comicsdb/templates/comicsdb/publisher_detail.html
+++ b/comicsdb/templates/comicsdb/publisher_detail.html
@@ -55,30 +55,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'publisher:update' publisher.slug %}"
-                       title="Edit this publisher">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'publisher:history' publisher.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_publisher %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'publisher:delete' publisher.slug %}"
-                           title="Delete this publisher">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="publisher-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="publisher-actions-menu"
+                                    hx-on:click="document.getElementById('publisher-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="publisher-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'publisher:update' publisher.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'publisher:history' publisher.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_publisher %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'publisher:delete' publisher.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 {% endif %}
             </div>
         </div>
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('publisher-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Publisher Logo #}

--- a/comicsdb/templates/comicsdb/series_detail.html
+++ b/comicsdb/templates/comicsdb/series_detail.html
@@ -49,36 +49,58 @@
                     <span>Issue List</span>
                 </a>
                 {% if user.is_authenticated %}
+                    {% include "pull_list/partials/pull_list_button.html" with series=series on_pull_list=on_pull_list %}
                     <a class="button is-rounded is-primary"
                        href="{% url 'series:create' %}"
                        title="Add a new series">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'series:update' series.slug %}"
-                       title="Edit this series">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'series:history' series.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_series %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'series:delete' series.slug %}"
-                           title="Delete this series">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="series-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="series-actions-menu"
+                                    hx-on:click="document.getElementById('series-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="series-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'series:update' series.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'series:history' series.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_series %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'series:delete' series.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 {% endif %}
             </div>
         </div>
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('series-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Series Cover #}

--- a/comicsdb/templates/comicsdb/team_detail.html
+++ b/comicsdb/templates/comicsdb/team_detail.html
@@ -49,30 +49,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'team:update' team.slug %}"
-                       title="Edit this team">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'team:history' team.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_team %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'team:delete' team.slug %}"
-                           title="Delete this team">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="team-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="team-actions-menu"
+                                    hx-on:click="document.getElementById('team-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="team-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'team:update' team.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'team:history' team.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_team %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'team:delete' team.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('team-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Team Image #}

--- a/comicsdb/templates/comicsdb/universe_detail.html
+++ b/comicsdb/templates/comicsdb/universe_detail.html
@@ -49,30 +49,51 @@
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
                         <span>New</span>
                     </a>
-                    <a class="button is-rounded is-info"
-                       href="{% url 'universe:update' universe.slug %}"
-                       title="Edit this universe">
-                        <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-rounded is-link"
-                       href="{% url 'universe:history' universe.slug %}"
-                       title="View edit history">
-                        <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                        <span>History</span>
-                    </a>
-                    {% if perms.comicsdb.delete_universe %}
-                        <a class="button is-rounded is-danger"
-                           href="{% url 'universe:delete' universe.slug %}"
-                           title="Delete this universe">
-                            <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                            <span>Delete</span>
-                        </a>
-                    {% endif %}
+                    <div class="dropdown is-right" id="universe-actions-dropdown">
+                        <div class="dropdown-trigger">
+                            <button class="button is-rounded"
+                                    aria-haspopup="true"
+                                    aria-controls="universe-actions-menu"
+                                    hx-on:click="document.getElementById('universe-actions-dropdown').classList.toggle('is-active')">
+                                <span>Actions</span>
+                                <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
+                            </button>
+                        </div>
+                        <div class="dropdown-menu" id="universe-actions-menu" role="menu">
+                            <div class="dropdown-content">
+                                <a class="dropdown-item"
+                                   href="{% url 'universe:update' universe.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a class="dropdown-item"
+                                   href="{% url 'universe:history' universe.slug %}">
+                                    <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
+                                    <span>History</span>
+                                </a>
+                                {% if perms.comicsdb.delete_universe %}
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item has-text-danger"
+                                       href="{% url 'universe:delete' universe.slug %}">
+                                        <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
+                                        <span>Delete</span>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         {% endif %}
     </nav>
+    <script>
+        document.addEventListener('click', function (e) {
+            var dropdown = document.getElementById('universe-actions-dropdown');
+            if (dropdown && !dropdown.contains(e.target)) {
+                dropdown.classList.remove('is-active');
+            }
+        });
+    </script>
     {# Main Content #}
     <div class="columns">
         {# Universe Image #}

--- a/comicsdb/views/issue.py
+++ b/comicsdb/views/issue.py
@@ -27,6 +27,7 @@ from comicsdb.models.variant import Variant
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
 from comicsdb.views.mixins import LazyLoadMixin, SlugRedirectView
+from wish_list.models import WishListItem
 
 TOTAL_WEEKS_YEAR = 52
 
@@ -170,6 +171,12 @@ class IssueDetail(DetailView):
         context["universes_count"] = universes_count
         if universes_count > 0:
             context["universes"] = universes[:DETAIL_PAGINATE_BY]
+
+        if self.request.user.is_authenticated:
+            context["on_wish_list"] = WishListItem.objects.filter(
+                wish_list__user=self.request.user,
+                issue=issue,
+            ).exists()
 
         return context
 

--- a/comicsdb/views/series.py
+++ b/comicsdb/views/series.py
@@ -18,6 +18,7 @@ from comicsdb.views.mixins import (
     AttributionUpdateMixin,
     SlugRedirectView,
 )
+from pull_list.models import PullListSeries
 
 LOGGER = logging.getLogger(__name__)
 
@@ -129,6 +130,13 @@ class SeriesDetail(DetailView):
         }
         context["creators"] = creators
         context["characters"] = characters
+
+        if self.request.user.is_authenticated:
+            context["on_pull_list"] = PullListSeries.objects.filter(
+                pull_list__user=self.request.user,
+                series=series,
+            ).exists()
+
         return context
 
 

--- a/pull_list/templates/pull_list/partials/pull_list_button.html
+++ b/pull_list/templates/pull_list/partials/pull_list_button.html
@@ -1,0 +1,11 @@
+<button id="pull-list-btn"
+        class="button is-rounded {% if on_pull_list %}is-info{% else %}is-light{% endif %}"
+        hx-post="{% url 'pull-list:toggle' series.slug %}"
+        hx-target="#pull-list-btn"
+        hx-swap="outerHTML"
+        title="{% if on_pull_list %}Remove from pull list{% else %}Add to pull list{% endif %}">
+    <span class="icon is-small">
+        <i class="{% if on_pull_list %}fas{% else %}far{% endif %} fa-bookmark" aria-hidden="true"></i>
+    </span>
+    <span>Pull List</span>
+</button>

--- a/pull_list/urls.py
+++ b/pull_list/urls.py
@@ -1,10 +1,15 @@
 from django.urls import path
 
-from pull_list.views import PullListDetailView, RemoveSeriesFromPullListView
+from pull_list.views import (
+    PullListDetailView,
+    RemoveSeriesFromPullListView,
+    toggle_pull_list_series,
+)
 
 app_name = "pull-list"
 
 urlpatterns = [
     path("", PullListDetailView.as_view(), name="detail"),
     path("remove/<int:series_pk>/", RemoveSeriesFromPullListView.as_view(), name="remove-series"),
+    path("toggle/<slug:slug>/", toggle_pull_list_series, name="toggle"),
 ]

--- a/pull_list/views.py
+++ b/pull_list/views.py
@@ -1,11 +1,14 @@
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 from django.views.generic import DeleteView, FormView
 
 from comicsdb.models.issue import Issue
+from comicsdb.models.series import Series
 from pull_list.forms import AddSeriesToPullListForm
 from pull_list.models import PullList, PullListSeries
 
@@ -77,3 +80,23 @@ class RemoveSeriesFromPullListView(LoginRequiredMixin, UserPassesTestMixin, Dele
         result = super().form_valid(form)
         messages.success(self.request, f"Removed {series_name} from your pull list.")
         return result
+
+
+@login_required
+@require_POST
+def toggle_pull_list_series(request, slug):
+    series = get_object_or_404(Series, slug=slug)
+    pull_list, _ = PullList.objects.get_or_create(user=request.user)
+    pull_list_series, created = PullListSeries.objects.get_or_create(
+        pull_list=pull_list, series=series
+    )
+    if not created:
+        pull_list_series.delete()
+        on_pull_list = False
+    else:
+        on_pull_list = True
+    return render(
+        request,
+        "pull_list/partials/pull_list_button.html",
+        {"series": series, "on_pull_list": on_pull_list},
+    )

--- a/static/site/css/home/index.css
+++ b/static/site/css/home/index.css
@@ -1,3 +1,14 @@
+/* Alternating section background that adapts to dark mode */
+.has-background-section-alt {
+    background-color: hsl(0, 0%, 96%);
+}
+
+@media (prefers-color-scheme: dark) {
+    .has-background-section-alt {
+        background-color: hsl(0, 0%, 17%);
+    }
+}
+
 /* Timeline styles for the home page */
 #timeline {
     margin: 0 1em;

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -1,8 +1,4 @@
 {% load static %}
-{% comment %}
-    Main navigation bar with dropdown menus
-    Includes authentication state and responsive mobile menu
-{% endcomment %}
 <nav class="navbar is-link is-fixed-top"
      role="navigation"
      aria-label="main navigation">
@@ -31,187 +27,193 @@
     <div id="navMenu" class="navbar-menu">
         <div class="navbar-start">
             {# Releases Menu #}
+            <div class="navbar-item has-dropdown is-hoverable">
+                <a class="navbar-link" aria-haspopup="true" aria-expanded="false">Releases</a>
+                <div class="navbar-dropdown">
+                    <a class="navbar-item" href="{% url 'issue:thisweek' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-star"></i>
+                        </span>
+                        <span>This Week</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'issue:nextweek' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-bolt"></i>
+                        </span>
+                        <span>Next Week</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'issue:future' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-gem"></i>
+                        </span>
+                        <span>Future</span>
+                    </a>
+                </div>
+            </div>
+            {# Browse Menu #}
+            <div class="navbar-item has-dropdown is-hoverable">
+                <a class="navbar-link" aria-haspopup="true" aria-expanded="false">Browse</a>
+                <div class="navbar-dropdown">
+                    <a class="navbar-item" href="{% url 'publisher:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-building"></i>
+                        </span>
+                        <span>Publishers</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'imprint:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-bookmark"></i>
+                        </span>
+                        <span>Imprints</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'series:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-list"></i>
+                        </span>
+                        <span>Series</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'issue:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-book"></i>
+                        </span>
+                        <span>Issues</span>
+                    </a>
+                    <hr class="navbar-divider" role="separator">
+                    <a class="navbar-item" href="{% url 'creator:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-pencil-alt"></i>
+                        </span>
+                        <span>Creators</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'character:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-mask"></i>
+                        </span>
+                        <span>Characters</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'team:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-users"></i>
+                        </span>
+                        <span>Teams</span>
+                    </a>
+                    <hr class="navbar-divider" role="separator">
+                    <a class="navbar-item" href="{% url 'arc:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-project-diagram"></i>
+                        </span>
+                        <span>Story Arcs</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'universe:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-globe"></i>
+                        </span>
+                        <span>Universes</span>
+                    </a>
+                    <hr class="navbar-divider" role="separator">
+                    <a class="navbar-item" href="{% url 'reading-list:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-book-reader"></i>
+                        </span>
+                        <span>Reading Lists</span>
+                    </a>
+                </div>
+            </div>
+            {# My Library Menu #}
+            {% if user.is_authenticated %}
                 <div class="navbar-item has-dropdown is-hoverable">
-                    <a class="navbar-link" aria-haspopup="true" aria-expanded="false">Releases</a>
+                    <a class="navbar-link" aria-haspopup="true" aria-expanded="false">My Library</a>
                     <div class="navbar-dropdown">
-                        <a class="navbar-item" href="{% url 'issue:thisweek' %}">
+                        <a class="navbar-item" href="{% url 'reading-list:my-lists' %}">
+                            <span class="icon" aria-hidden="true">
+                                <i class="fas fa-clipboard-check"></i>
+                            </span>
+                            <span>My Reading Lists</span>
+                        </a>
+                        <a class="navbar-item" href="{% url 'user_collection:list' %}">
+                            <span class="icon" aria-hidden="true">
+                                <i class="fas fa-box-open"></i>
+                            </span>
+                            <span>My Collection</span>
+                        </a>
+                        <a class="navbar-item" href="{% url 'pull-list:detail' %}">
+                            <span class="icon" aria-hidden="true">
+                                <i class="fas fa-shopping-basket"></i>
+                            </span>
+                            <span>My Pull List</span>
+                        </a>
+                        <a class="navbar-item" href="{% url 'wish-list:detail' %}">
                             <span class="icon" aria-hidden="true">
                                 <i class="fas fa-star"></i>
                             </span>
-                            <span>This Week</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'issue:nextweek' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-bolt"></i>
-                            </span>
-                            <span>Next Week</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'issue:future' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-gem"></i>
-                            </span>
-                            <span>Future</span>
+                            <span>My Wish List</span>
                         </a>
                     </div>
                 </div>
-                {# Browse Menu #}
-                <div class="navbar-item has-dropdown is-hoverable">
-                    <a class="navbar-link" aria-haspopup="true" aria-expanded="false">Browse</a>
-                    <div class="navbar-dropdown">
-                        <a class="navbar-item" href="{% url 'publisher:list' %}">
+            {% endif %}
+            {# More Menu #}
+            <div class="navbar-item has-dropdown is-hoverable">
+                <a class="navbar-link" aria-haspopup="true" aria-expanded="false">More</a>
+                <div class="navbar-dropdown">
+                    <a class="navbar-item" href="{% url 'wiki:root' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-book-open"></i>
+                        </span>
+                        <span>Wiki</span>
+                    </a>
+                    {% if user.is_authenticated %}
+                        <a class="navbar-item" href="/docs/">
                             <span class="icon" aria-hidden="true">
-                                <i class="fas fa-building"></i>
+                                <i class="fas fa-file"></i>
                             </span>
-                            <span>Publishers</span>
+                            <span>API Docs</span>
                         </a>
-                        <a class="navbar-item" href="{% url 'imprint:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-bookmark"></i>
-                            </span>
-                            <span>Imprints</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'series:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-list"></i>
-                            </span>
-                            <span>Series</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'issue:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-book"></i>
-                            </span>
-                            <span>Issues</span>
-                        </a>
-                        <hr class="navbar-divider" role="separator">
-                        <a class="navbar-item" href="{% url 'creator:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-pencil-alt"></i>
-                            </span>
-                            <span>Creators</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'character:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-mask"></i>
-                            </span>
-                            <span>Characters</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'team:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-users"></i>
-                            </span>
-                            <span>Teams</span>
-                        </a>
-                        <hr class="navbar-divider" role="separator">
-                        <a class="navbar-item" href="{% url 'arc:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-project-diagram"></i>
-                            </span>
-                            <span>Story Arcs</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'universe:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-globe"></i>
-                            </span>
-                            <span>Universes</span>
-                        </a>
-                        <hr class="navbar-divider" role="separator">
-                        <a class="navbar-item" href="{% url 'reading-list:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-book-reader"></i>
-                            </span>
-                            <span>Reading Lists</span>
-                        </a>
-                        {% if user.is_authenticated %}
-                            <a class="navbar-item" href="{% url 'reading-list:my-lists' %}">
-                                <span class="icon" aria-hidden="true">
-                                    <i class="fas fa-clipboard-check"></i>
-                                </span>
-                                <span>My Reading Lists</span>
-                            </a>
-                            <a class="navbar-item" href="{% url 'user_collection:list' %}">
-                                <span class="icon" aria-hidden="true">
-                                    <i class="fas fa-box-open"></i>
-                                </span>
-                                <span>My Collection</span>
-                            </a>
-                            <a class="navbar-item" href="{% url 'pull-list:detail' %}">
-                                <span class="icon" aria-hidden="true">
-                                    <i class="fas fa-shopping-basket"></i>
-                                </span>
-                                <span>My Pull List</span>
-                            </a>
-                            <a class="navbar-item" href="{% url 'wish-list:detail' %}">
-                                <span class="icon" aria-hidden="true">
-                                    <i class="fas fa-star"></i>
-                                </span>
-                                <span>My Wish List</span>
-                            </a>
-                        {% endif %}
-                    </div>
+                    {% endif %}
+                    <a class="navbar-item" href="{% url 'polls:list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-poll"></i>
+                        </span>
+                        <span>Polls</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'statistics' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-chart-bar"></i>
+                        </span>
+                        <span>Statistics</span>
+                    </a>
+                    <a class="navbar-item" href="{% url 'user-list' %}">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-users"></i>
+                        </span>
+                        <span>Users</span>
+                    </a>
+                    <a class="navbar-item"
+                       href="https://metron-project.github.io/blog"
+                       target="_blank"
+                       rel="noopener noreferrer">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-blog"></i>
+                        </span>
+                        <span>Blog</span>
+                        <span class="icon is-small" aria-hidden="true">
+                            <i class="fas fa-external-link-alt"></i>
+                        </span>
+                    </a>
+                    <hr class="navbar-divider" role="separator">
+                    <a class="navbar-item"
+                       href="https://github.com/Metron-Project/metron/issues/new/choose"
+                       target="_blank"
+                       rel="noopener noreferrer">
+                        <span class="icon" aria-hidden="true">
+                            <i class="fas fa-bug"></i>
+                        </span>
+                        <span>Report an Issue</span>
+                        <span class="icon is-small" aria-hidden="true">
+                            <i class="fas fa-external-link-alt"></i>
+                        </span>
+                    </a>
                 </div>
-                {# More Menu #}
-                <div class="navbar-item has-dropdown is-hoverable">
-                    <a class="navbar-link" aria-haspopup="true" aria-expanded="false">More</a>
-                    <div class="navbar-dropdown">
-                        <a class="navbar-item" href="{% url 'wiki:root' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-book-open"></i>
-                            </span>
-                            <span>Wiki</span>
-                        </a>
-                        {% if user.is_authenticated %}
-                            <a class="navbar-item" href="/docs/">
-                                <span class="icon" aria-hidden="true">
-                                    <i class="fas fa-file"></i>
-                                </span>
-                                <span>API Docs</span>
-                            </a>
-                        {% endif %}
-                        <a class="navbar-item" href="{% url 'polls:list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-poll"></i>
-                            </span>
-                            <span>Polls</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'statistics' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-chart-bar"></i>
-                            </span>
-                            <span>Statistics</span>
-                        </a>
-                        <a class="navbar-item" href="{% url 'user-list' %}">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-users"></i>
-                            </span>
-                            <span>Users</span>
-                        </a>
-                        <a class="navbar-item"
-                           href="https://metron-project.github.io/blog"
-                           target="_blank"
-                           rel="noopener noreferrer">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-blog"></i>
-                            </span>
-                            <span>Blog</span>
-                            <span class="icon is-small" aria-hidden="true">
-                                <i class="fas fa-external-link-alt"></i>
-                            </span>
-                        </a>
-                        <hr class="navbar-divider" role="separator">
-                        <a class="navbar-item"
-                           href="https://github.com/Metron-Project/metron/issues/new/choose"
-                           target="_blank"
-                           rel="noopener noreferrer">
-                            <span class="icon" aria-hidden="true">
-                                <i class="fas fa-bug"></i>
-                            </span>
-                            <span>Report an Issue</span>
-                            <span class="icon is-small" aria-hidden="true">
-                                <i class="fas fa-external-link-alt"></i>
-                            </span>
-                        </a>
-                    </div>
-                </div>
+            </div>
         </div>
         <div class="navbar-end">
             {# Social Links #}

--- a/tests/comicsdb/test_issue_views.py
+++ b/tests/comicsdb/test_issue_views.py
@@ -10,6 +10,7 @@ from comicsdb.models.credits import Role
 from comicsdb.models.issue import Issue
 from comicsdb.models.publisher import Publisher
 from comicsdb.models.series import Series, SeriesType
+from wish_list.models import WishList, WishListItem
 
 HTML_OK_CODE = 200
 HTML_REDIRECT_CODE = 302
@@ -29,6 +30,22 @@ def test_issue_redirect(basic_issue, auto_login_user):
     client, _ = auto_login_user()
     resp = client.get(f"/issue/{basic_issue.pk}/")
     assert resp.status_code == HTML_REDIRECT_CODE
+
+
+def test_issue_detail_on_wish_list_false_when_not_on_list(basic_issue, auto_login_user):
+    client, _ = auto_login_user()
+    resp = client.get(f"/issue/{basic_issue.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["on_wish_list"] is False
+
+
+def test_issue_detail_on_wish_list_true_when_on_list(basic_issue, auto_login_user):
+    client, user = auto_login_user()
+    wish_list = WishList.objects.create(user=user)
+    WishListItem.objects.create(wish_list=wish_list, issue=basic_issue)
+    resp = client.get(f"/issue/{basic_issue.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["on_wish_list"] is True
 
 
 # Issue Search

--- a/tests/comicsdb/test_series_views.py
+++ b/tests/comicsdb/test_series_views.py
@@ -5,6 +5,7 @@ from pytest_django.asserts import assertTemplateUsed
 from comicsdb.forms.series import SeriesForm
 from comicsdb.models import Genre, Imprint, Publisher, Series, SeriesType
 from comicsdb.models.attribution import Attribution
+from pull_list.models import PullList, PullListSeries
 
 HTML_OK_CODE = 200
 HTML_REDIRECT_CODE = 302
@@ -43,6 +44,22 @@ def test_series_redirect(sandman_series, auto_login_user):
     client, _ = auto_login_user()
     resp = client.get(f"/series/{sandman_series.pk}/")
     assert resp.status_code == HTML_REDIRECT_CODE
+
+
+def test_series_detail_on_pull_list_false_when_not_on_list(sandman_series, auto_login_user):
+    client, _ = auto_login_user()
+    resp = client.get(f"/series/{sandman_series.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["on_pull_list"] is False
+
+
+def test_series_detail_on_pull_list_true_when_on_list(sandman_series, auto_login_user):
+    client, user = auto_login_user()
+    pull_list = PullList.objects.create(user=user)
+    PullListSeries.objects.create(pull_list=pull_list, series=sandman_series)
+    resp = client.get(f"/series/{sandman_series.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["on_pull_list"] is True
 
 
 def test_series_search_view_url_exists_at_desired_location(auto_login_user):

--- a/tests/pull_list/test_views.py
+++ b/tests/pull_list/test_views.py
@@ -5,6 +5,55 @@ from django.urls import reverse
 from pull_list.models import PullList, PullListSeries
 
 
+# Toggle view
+def test_toggle_requires_login(client, pull_list_series):
+    resp = client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 302
+    assert "/accounts/login" in resp["Location"]
+
+
+def test_toggle_get_not_allowed(client, pull_list_user, test_password, pull_list_series):
+    client.login(username=pull_list_user.username, password=test_password)
+    resp = client.get(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 405
+
+
+def test_toggle_adds_series_to_pull_list(client, pull_list_user, test_password, pull_list_series):
+    client.login(username=pull_list_user.username, password=test_password)
+    resp = client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 200
+    assert PullListSeries.objects.filter(
+        pull_list__user=pull_list_user, series=pull_list_series
+    ).exists()
+
+
+def test_toggle_removes_series_from_pull_list(
+    client, pull_list_user, test_password, pull_list_with_series, pull_list_series
+):
+    client.login(username=pull_list_user.username, password=test_password)
+    resp = client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 200
+    assert not PullListSeries.objects.filter(
+        pull_list__user=pull_list_user, series=pull_list_series
+    ).exists()
+
+
+def test_toggle_response_contains_button(client, pull_list_user, test_password, pull_list_series):
+    client.login(username=pull_list_user.username, password=test_password)
+    resp = client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert resp.status_code == 200
+    assert b"pull-list-btn" in resp.content
+
+
+def test_toggle_creates_pull_list_if_missing(
+    client, pull_list_user, test_password, pull_list_series
+):
+    client.login(username=pull_list_user.username, password=test_password)
+    assert not PullList.objects.filter(user=pull_list_user).exists()
+    client.post(reverse("pull-list:toggle", kwargs={"slug": pull_list_series.slug}))
+    assert PullList.objects.filter(user=pull_list_user).exists()
+
+
 # Detail view — authentication
 def test_detail_view_requires_login(client):
     resp = client.get(reverse("pull-list:detail"))

--- a/tests/wish_list/test_views.py
+++ b/tests/wish_list/test_views.py
@@ -6,6 +6,55 @@ from user_collection.models import CollectionItem
 from wish_list.models import WishList, WishListItem
 
 
+# Toggle view
+def test_toggle_requires_login(client, wish_list_issue):
+    resp = client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 302
+    assert "/accounts/login" in resp["Location"]
+
+
+def test_toggle_get_not_allowed(client, wish_list_user, test_password, wish_list_issue):
+    client.login(username=wish_list_user.username, password=test_password)
+    resp = client.get(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 405
+
+
+def test_toggle_adds_issue_to_wish_list(client, wish_list_user, test_password, wish_list_issue):
+    client.login(username=wish_list_user.username, password=test_password)
+    resp = client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 200
+    assert WishListItem.objects.filter(
+        wish_list__user=wish_list_user, issue=wish_list_issue
+    ).exists()
+
+
+def test_toggle_removes_issue_from_wish_list(
+    client, wish_list_user, test_password, wish_list_item, wish_list_issue
+):
+    client.login(username=wish_list_user.username, password=test_password)
+    resp = client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 200
+    assert not WishListItem.objects.filter(
+        wish_list__user=wish_list_user, issue=wish_list_issue
+    ).exists()
+
+
+def test_toggle_response_contains_button(client, wish_list_user, test_password, wish_list_issue):
+    client.login(username=wish_list_user.username, password=test_password)
+    resp = client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert resp.status_code == 200
+    assert b"wish-list-btn" in resp.content
+
+
+def test_toggle_creates_wish_list_if_missing(
+    client, wish_list_user, test_password, wish_list_issue
+):
+    client.login(username=wish_list_user.username, password=test_password)
+    assert not WishList.objects.filter(user=wish_list_user).exists()
+    client.post(reverse("wish-list:toggle", kwargs={"slug": wish_list_issue.slug}))
+    assert WishList.objects.filter(user=wish_list_user).exists()
+
+
 # Detail view — authentication
 def test_detail_view_requires_login(client):
     resp = client.get(reverse("wish-list:detail"))
@@ -21,7 +70,7 @@ def test_detail_view_authenticated_creates_wish_list(client, wish_list_user, tes
     assert WishList.objects.filter(user=wish_list_user).exists()
 
 
-def test_detail_view_shows_items(client, wish_list_user, test_password, wish_list_item, wish_list):
+def test_detail_view_shows_items(client, wish_list_user, test_password, wish_list_item):
     client.login(username=wish_list_user.username, password=test_password)
     resp = client.get(reverse("wish-list:detail"))
     assert resp.status_code == 200
@@ -53,9 +102,7 @@ def test_add_duplicate_item_shows_info(
 
 
 # Item update view
-def test_item_update_requires_owner(
-    client, other_wish_list_user, test_password, wish_list_item, wish_list_issue
-):
+def test_item_update_requires_owner(client, other_wish_list_user, test_password, wish_list_item):
     client.login(username=other_wish_list_user.username, password=test_password)
     resp = client.get(reverse("wish-list:item-update", kwargs={"pk": wish_list_item.pk}))
     assert resp.status_code == 403

--- a/wish_list/templates/wish_list/partials/wish_list_button.html
+++ b/wish_list/templates/wish_list/partials/wish_list_button.html
@@ -1,0 +1,11 @@
+<button id="wish-list-btn"
+        class="button is-rounded {% if on_wish_list %}is-warning{% else %}is-light{% endif %}"
+        hx-post="{% url 'wish-list:toggle' issue.slug %}"
+        hx-target="#wish-list-btn"
+        hx-swap="outerHTML"
+        title="{% if on_wish_list %}Remove from wish list{% else %}Add to wish list{% endif %}">
+    <span class="icon is-small">
+        <i class="{% if on_wish_list %}fas{% else %}far{% endif %} fa-bookmark" aria-hidden="true"></i>
+    </span>
+    <span>Wish List</span>
+</button>

--- a/wish_list/urls.py
+++ b/wish_list/urls.py
@@ -5,6 +5,7 @@ from wish_list.views import (
     WishListDetailView,
     WishListItemDeleteView,
     WishListItemUpdateView,
+    toggle_wish_list_item,
 )
 
 app_name = "wish-list"
@@ -14,4 +15,5 @@ urlpatterns = [
     path("item/<int:pk>/update/", WishListItemUpdateView.as_view(), name="item-update"),
     path("item/<int:pk>/delete/", WishListItemDeleteView.as_view(), name="item-delete"),
     path("item/<int:pk>/acquire/", AcquireWishListItemView.as_view(), name="item-acquire"),
+    path("toggle/<slug:slug>/", toggle_wish_list_item, name="toggle"),
 ]

--- a/wish_list/views.py
+++ b/wish_list/views.py
@@ -1,9 +1,12 @@
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
+from django.views.decorators.http import require_POST
 from django.views.generic import DeleteView, FormView, UpdateView
 
+from comicsdb.models.issue import Issue
 from user_collection.models import CollectionItem
 from wish_list.forms import AcquireWishListItemForm, WishListItemForm
 from wish_list.models import WishList, WishListItem
@@ -117,3 +120,21 @@ class AcquireWishListItemView(LoginRequiredMixin, UserPassesTestMixin, FormView)
         context = super().get_context_data(**kwargs)
         context["item"] = self.wish_list_item
         return context
+
+
+@login_required
+@require_POST
+def toggle_wish_list_item(request, slug):
+    issue = get_object_or_404(Issue, slug=slug)
+    wish_list, _ = WishList.objects.get_or_create(user=request.user)
+    item, created = WishListItem.objects.get_or_create(wish_list=wish_list, issue=issue)
+    if not created:
+        item.delete()
+        on_wish_list = False
+    else:
+        on_wish_list = True
+    return render(
+        request,
+        "wish_list/partials/wish_list_button.html",
+        {"issue": issue, "on_wish_list": on_wish_list},
+    )


### PR DESCRIPTION
## Summary

This branch refreshes several key areas of the site UI for a cleaner, more consistent user experience.

**Navbar reorganization**
- Splits the Browse dropdown: general browsing items stay in Browse, while user-specific links (My Collection, My Pull List, My Wish List, My Reading Lists) move to a new **My Library** dropdown that is only shown to authenticated users
- Fixes indentation of navbar-start dropdown elements

**Home page redesign**
- Replaces colored box cards with alternating plain sections, pairing related topics side-by-side in two-column desktop layouts
- Adds dark-mode-aware CSS for alternating section backgrounds
- Adds wish list and pull list summary information to the home page

**HTMX-powered toggle buttons on detail pages**
- Adds an HTMX wish list toggle button to issue detail pages so authenticated users can add/remove issues without a full page reload
- Adds an HTMX pull list toggle button to series detail pages for the same pattern

**Actions dropdown on all detail pages**
- Moves Edit, History, and Delete controls into a Bulma **Actions** dropdown on issue, series, arc, character, creator, imprint, publisher, team, and universe detail pages, reducing navbar clutter and providing a consistent editorial UX across all views
- Delete is separated by a divider and only shown to users with delete permission
