### PR TITLE
Redesign Home Page

### DIFF
--- a/comicsdb/templates/comicsdb/home.html
+++ b/comicsdb/templates/comicsdb/home.html
@@ -13,11 +13,11 @@
           content="Comics,Comic Book Database,API,REST,Metron,Community,Open Source">
 {% endblock %}
 {% block title %}Metron - Comic Book Database{% endblock %}
-{% block content %}
+{% block hero %}
     {# Announcements #}
     {% cache 1800 announcements_cache %}
     {% if active_announcements %}
-        <div class="announcements mb-5">
+        <div class="announcements px-4 pt-4">
             {% for announcement in active_announcements %}
                 <div class="notification is-{{ announcement.display_type }} is-light"
                      role="alert">
@@ -30,16 +30,21 @@
         </div>
     {% endif %}
     {% endcache %}
-    {# Hero Header #}
-    <section class="hero is-medium is-link home-hero">
-        <div class="hero-body">
+    {# Hero Header — full-width, Fedora-inspired #}
+    <section class="home-hero">
+        <div class="home-hero-body">
             <div class="container has-text-centered">
-                <p class="hero-eyebrow">Open Source Comic Book Database</p>
-                <h1 class="title is-1 hero-title mt-2">Metron</h1>
-                <p class="subtitle is-4 hero-subtitle mt-3">
+                <img src="{% static 'site/img/metron-300.png' %}"
+                     alt="Metron logo"
+                     class="home-hero-logo"
+                     width="120"
+                     height="120">
+                <h1 class="home-hero-title">Metron</h1>
+                <p class="home-hero-tagline">Comic Book Database</p>
+                <p class="home-hero-subtitle">
                     Built by the community, for the community.
                 </p>
-                <div class="buttons are-medium is-centered mt-5">
+                <div class="buttons are-medium is-centered home-hero-buttons">
                     <a href="{% url 'issue:list' %}" class="button is-light is-outlined">
                         <span class="icon"><i class="fas fa-book-open"></i></span>
                         <span>Browse Comics</span>
@@ -48,7 +53,7 @@
                         <span class="icon"><i class="fas fa-book"></i></span>
                         <span>Read the Wiki</span>
                     </a>
-                    <a href="{% url 'signup' %}" class="button is-primary is-light">
+                    <a href="{% url 'signup' %}" class="button is-link is-light">
                         <span class="icon"><i class="fas fa-user-plus"></i></span>
                         <span>Sign Up Free</span>
                     </a>
@@ -56,6 +61,8 @@
             </div>
         </div>
     </section>
+{% endblock %}
+{% block content %}
     {# What is Metron #}
     <section id="about" class="section">
         <div class="container">

--- a/comicsdb/templates/comicsdb/home.html
+++ b/comicsdb/templates/comicsdb/home.html
@@ -31,36 +31,27 @@
     {% endif %}
     {% endcache %}
     {# Hero Header #}
-    <section class="hero is-small is-link">
+    <section class="hero is-medium is-link home-hero">
         <div class="hero-body">
             <div class="container has-text-centered">
-                <h1 class="title is-1">Metron</h1>
-                <p class="subtitle is-3">Comic Book Database</p>
-                <div class="columns is-mobile mt-5">
-                    <div class="column has-text-centered">
-                        <div>
-                            <span class="icon is-large" aria-hidden="true">
-                                <i class="fas fa-database fa-2x"></i>
-                            </span>
-                            <p class="heading">Database</p>
-                        </div>
-                    </div>
-                    <div class="column has-text-centered">
-                        <div>
-                            <span class="icon is-large" aria-hidden="true">
-                                <i class="fas fa-satellite-dish fa-2x"></i>
-                            </span>
-                            <p class="heading">REST API</p>
-                        </div>
-                    </div>
-                    <div class="column has-text-centered">
-                        <div>
-                            <span class="icon is-large" aria-hidden="true">
-                                <i class="fas fa-users fa-2x"></i>
-                            </span>
-                            <p class="heading">Community</p>
-                        </div>
-                    </div>
+                <p class="hero-eyebrow">Open Source Comic Book Database</p>
+                <h1 class="title is-1 hero-title mt-2">Metron</h1>
+                <p class="subtitle is-4 hero-subtitle mt-3">
+                    Built by the community, for the community.
+                </p>
+                <div class="buttons are-medium is-centered mt-5">
+                    <a href="{% url 'issue:list' %}" class="button is-light is-outlined">
+                        <span class="icon"><i class="fas fa-book-open"></i></span>
+                        <span>Browse Comics</span>
+                    </a>
+                    <a href="{% url 'wiki:root' %}" class="button is-white">
+                        <span class="icon"><i class="fas fa-book"></i></span>
+                        <span>Read the Wiki</span>
+                    </a>
+                    <a href="{% url 'signup' %}" class="button is-primary is-light">
+                        <span class="icon"><i class="fas fa-user-plus"></i></span>
+                        <span>Sign Up Free</span>
+                    </a>
                 </div>
             </div>
         </div>
@@ -68,8 +59,14 @@
     {# What is Metron #}
     <section id="about" class="section">
         <div class="container">
-            <h2 class="is-size-2">What is Metron?</h2>
-            <div class="content mt-4">
+            <div class="has-text-centered mb-5">
+                <h2 class="title is-2">What is Metron?</h2>
+                <p class="subtitle is-5 home-section-intro">
+                    A community-built, open database for comic book metadata — free from corporate control.
+                </p>
+                <div class="home-section-divider"></div>
+            </div>
+            <div class="content home-about-content">
                 <p>
                     <strong>Metron</strong> is a community-based site whose goal is to build an open database
                     with a <a href="https://en.wikipedia.org/wiki/Representational_state_transfer"
@@ -95,95 +92,172 @@
             </div>
         </div>
     </section>
-    {# REST API + Reading Lists & Collections #}
+    {# Features — Fedora-style edition cards #}
     <section id="features" class="section has-background-section-alt">
         <div class="container">
-            <div class="columns is-desktop">
-                <div class="column is-half-desktop">
-                    <h2 class="is-size-2">Using the REST API</h2>
-                    <div class="content mt-4">
-                        <p>
-                            If you want to use data from Metron, there is a <a href="https://www.python.org/"
-    target="_blank"
-    rel="noopener noreferrer">Python</a> wrapper called
-                            <a href="https://github.com/Metron-Project/mokkari"
-    target="_blank"
-    rel="noopener noreferrer">Mokkari</a> to make it easy to use the API.
-                        </p>
-                        <p>Want to tag your comic archives with metadata from Metron? You can use these projects:</p>
-                        <ul>
-                            <li>
-                                <a href="https://github.com/Metron-Project/metron-tagger"
-                                   target="_blank"
-                                   rel="noopener noreferrer">Metron-Tagger</a>
-                            </li>
-                            <li>
-                                <a href="https://github.com/Buried-In-Code/Perdoo"
-                                   target="_blank"
-                                   rel="noopener noreferrer">Perdoo</a>
-                            </li>
-                            <li>
-                                <s><a href="https://github.com/comictagger/comictagger/issues/783"
-   target="_blank"
-   rel="noopener noreferrer">Comic Tagger</a></s> (No longer supported)
-                            </li>
-                        </ul>
-                        <p>
-                            For more information on the API, please refer to the
-                            <a href="{% url 'wiki:root' %}">Wiki</a>.
-                        </p>
+            <div class="has-text-centered mb-5">
+                <h2 class="title is-2">What Metron Offers</h2>
+                <p class="subtitle is-5 home-section-intro">
+                    Everything you need to discover, track, and organize your comic collection.
+                </p>
+                <div class="home-section-divider"></div>
+            </div>
+            <div class="columns is-multiline">
+                <div class="column is-one-third-desktop is-half-tablet">
+                    <div class="card home-feature-card is-height-100">
+                        <div class="card-content">
+                            <div class="has-text-centered mb-4">
+                                <span class="icon is-large home-feature-icon">
+                                    <i class="fas fa-satellite-dish fa-2x"></i>
+                                </span>
+                            </div>
+                            <p class="title is-4 has-text-centered">REST API</p>
+                            <div class="content">
+                                <p>
+                                    Access comic book metadata programmatically. Use the Python wrapper
+                                    <a href="https://github.com/Metron-Project/mokkari"
+                                       target="_blank"
+                                       rel="noopener noreferrer">Mokkari</a>
+                                    to integrate Metron data into your projects with ease.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'wiki:root' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-book"></i></span>
+                                <span>Read the Wiki</span>
+                            </a>
+                        </div>
                     </div>
                 </div>
-                <div class="column is-half-desktop">
-                    <h2 class="is-size-2">Reading Lists & Collections</h2>
-                    <div class="content mt-4">
-                        <p>
-                            Metron supports <strong>Reading Lists</strong> and <strong>Collections</strong> to help you organize and track your comics!
-                        </p>
-                        <p>
-                            <strong>Reading Lists</strong> allow you to create custom lists of issues you want to read, mark your progress, and share your reading order with others.
-                        </p>
-                        <p>
-                            <strong>Collections</strong> let you catalog and organize the comics you own, making it easy to keep track of your personal library. Track grades, purchase history, reading status, and rate your comics.
-                        </p>
-                        <p>
-                            <strong>Quick Scrobble:</strong> Mark issues as read instantly via our API — useful for comic servers!
-                        </p>
+                <div class="column is-one-third-desktop is-half-tablet">
+                    <div class="card home-feature-card is-height-100">
+                        <div class="card-content">
+                            <div class="has-text-centered mb-4">
+                                <span class="icon is-large home-feature-icon">
+                                    <i class="fas fa-boxes fa-2x"></i>
+                                </span>
+                            </div>
+                            <p class="title is-4 has-text-centered">Collections</p>
+                            <div class="content">
+                                <p>
+                                    Catalog and organize the comics you own. Track grades, purchase history, reading
+                                    status, and personal ratings for your physical or digital library.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'signup' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-user-plus"></i></span>
+                                <span>Get Started</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-one-third-desktop is-half-tablet">
+                    <div class="card home-feature-card is-height-100">
+                        <div class="card-content">
+                            <div class="has-text-centered mb-4">
+                                <span class="icon is-large home-feature-icon">
+                                    <i class="fas fa-tasks fa-2x"></i>
+                                </span>
+                            </div>
+                            <p class="title is-4 has-text-centered">Reading Lists</p>
+                            <div class="content">
+                                <p>
+                                    Create custom lists of issues to read, mark your progress, and share your reading
+                                    order with others. Perfect for story arcs and event crossovers.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'signup' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-user-plus"></i></span>
+                                <span>Get Started</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-one-third-desktop is-half-tablet">
+                    <div class="card home-feature-card is-height-100">
+                        <div class="card-content">
+                            <div class="has-text-centered mb-4">
+                                <span class="icon is-large home-feature-icon">
+                                    <i class="fas fa-heart fa-2x"></i>
+                                </span>
+                            </div>
+                            <p class="title is-4 has-text-centered">Wish List</p>
+                            <div class="content">
+                                <p>
+                                    Keep track of issues you want to acquire. Never lose track of the comics you're
+                                    hunting for while shopping or trading with other collectors.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'signup' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-user-plus"></i></span>
+                                <span>Get Started</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-one-third-desktop is-half-tablet">
+                    <div class="card home-feature-card is-height-100">
+                        <div class="card-content">
+                            <div class="has-text-centered mb-4">
+                                <span class="icon is-large home-feature-icon">
+                                    <i class="fas fa-rss fa-2x"></i>
+                                </span>
+                            </div>
+                            <p class="title is-4 has-text-centered">Pull List</p>
+                            <div class="content">
+                                <p>
+                                    Follow the series you love. Add ongoing titles to your pull list and get a
+                                    consolidated view of everything you're currently collecting.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'signup' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-user-plus"></i></span>
+                                <span>Get Started</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-one-third-desktop is-half-tablet">
+                    <div class="card home-feature-card is-height-100">
+                        <div class="card-content">
+                            <div class="has-text-centered mb-4">
+                                <span class="icon is-large home-feature-icon">
+                                    <i class="fas fa-bolt fa-2x"></i>
+                                </span>
+                            </div>
+                            <p class="title is-4 has-text-centered">Quick Scrobble</p>
+                            <div class="content">
+                                <p>
+                                    Mark issues as read instantly via the API — great for comic servers and automation.
+                                    Manage reading history programmatically at <code>/api/collection/</code>.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'wiki:root' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-book"></i></span>
+                                <span>Read the Wiki</span>
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-        <div class="columns is-desktop mt-5">
-            <div class="column is-half-desktop">
-                <h2 class="is-size-2">Wish List</h2>
-                <div class="content mt-4">
-                    <p>
-                        Keep track of issues you want to acquire with your personal <strong>Wish List</strong>.
-                        Add issues you're hunting for so you never lose track of them while shopping or trading.
-                    </p>
-                    <p>Wish list management is also available via the REST API at <code>/api/wish_list/</code>.</p>
-                </div>
-            </div>
-            <div class="column is-half-desktop">
-                <h2 class="is-size-2">Pull List</h2>
-                <div class="content mt-4">
-                    <p>
-                        Follow the series you love with your <strong>Pull List</strong>. Add ongoing titles
-                        you're collecting to get a consolidated view of everything you're currently following.
-                    </p>
-                    <p>Pull list management is also available via the REST API at <code>/api/pull_list/</code>.</p>
-                </div>
-            </div>
-        </div>
-        <p class="mt-5">
-            <a href="{% url 'signup' %}">Create an account</a> to start using these features today!
-        </p>
     </section>
     {# Timeline #}
     <section id="timeline" class="section has-text-centered">
         <div class="container">
             <article class="box">
-                <header class="title">Interactive timeline</header>
+                <header class="title">Interactive Timeline</header>
                 <div class="mini-timeline">
                     <i class="fa fa-asterisk"></i>
                     <i class="fa fa-code"></i>
@@ -197,61 +271,146 @@
                 <div class="buttons are-medium is-centered">
                     <a href="{% url 'timeline:timeline' %}" class="button is-primary">
                         <span>Check it out!</span>
-                        <span class="icon">
-                            <i class="fas fa-arrow-right"></i>
-                        </span>
+                        <span class="icon"><i class="fas fa-arrow-right"></i></span>
                     </a>
                 </div>
             </article>
         </div>
     </section>
-    {# Contribute + Questions #}
+    {# Get Involved #}
     <section id="community" class="section has-background-section-alt">
         <div class="container">
-            <div class="columns is-desktop">
-                <div class="column is-half-desktop">
-                    <h2 class="is-size-2">Want to Contribute?</h2>
-                    <div class="content mt-4">
-                        <p>
-                            If you would like to donate to help cover server and development costs, you can support us through
-                            <a href="https://opencollective.com/metron"
-                               target="_blank"
-                               rel="noopener noreferrer">OpenCollective</a>.
-                        </p>
-                        <p>
-                            If you want to add information to Metron, sign up for an account and read the
-                            <a href="{% url 'wiki:root' %}">Wiki</a> before starting.
-                        </p>
-                        <p>
-                            Want to help with the technical side of Metron? Metron is built with
-                            <a href="https://www.djangoproject.com/"
-                               target="_blank"
-                               rel="noopener noreferrer">Django</a>. If you have knowledge of Python and Django, head over to
-                            <a href="https://github.com/Metron-Project/metron"
-    target="_blank"
-    rel="noopener noreferrer">GitHub</a> to check out the site's code.
-                        </p>
+            <div class="has-text-centered mb-5">
+                <h2 class="title is-2">Get Involved</h2>
+                <p class="subtitle is-5 home-section-intro">
+                    Metron is a community project — everyone is welcome to contribute.
+                </p>
+                <div class="home-section-divider"></div>
+            </div>
+            <div class="columns is-multiline">
+                <div class="column is-one-third-desktop">
+                    <div class="card home-community-card is-height-100">
+                        <div class="card-content has-text-centered">
+                            <span class="icon is-large home-feature-icon mb-3">
+                                <i class="fas fa-database fa-2x"></i>
+                            </span>
+                            <p class="title is-5 mt-3">Add Comic Data</p>
+                            <div class="content">
+                                <p>
+                                    Sign up for an account and help grow the database.
+                                    Read the <a href="{% url 'wiki:root' %}">Wiki</a> to learn the contribution guidelines before getting started.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'signup' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-user-plus"></i></span>
+                                <span>Create Account</span>
+                            </a>
+                        </div>
                     </div>
                 </div>
-                <div class="column is-half-desktop">
-                    <h2 class="is-size-2">Questions?</h2>
-                    <div class="content mt-4">
-                        <p>Have questions not covered here or suggestions? Feel free to contact us at any of these places:</p>
-                        <ul>
-                            <li>
-                                <a href="https://matrix.to/#/#metrondb:matrix.org"
-                                   target="_blank"
-                                   rel="noopener noreferrer">Matrix Chat</a>
-                            </li>
-                            <li>
-                                <a href="https://github.com/Metron-Project/metron/discussions"
-                                   target="_blank"
-                                   rel="noopener noreferrer">GitHub Discussions</a>
-                            </li>
-                            <li>
-                                <a href="mailto:admin@metron.cloud">Email Site Admin</a>
-                            </li>
-                        </ul>
+                <div class="column is-one-third-desktop">
+                    <div class="card home-community-card is-height-100">
+                        <div class="card-content has-text-centered">
+                            <span class="icon is-large home-feature-icon mb-3">
+                                <i class="fab fa-github fa-2x"></i>
+                            </span>
+                            <p class="title is-5 mt-3">Contribute Code</p>
+                            <div class="content">
+                                <p>
+                                    Metron is built with
+                                    <a href="https://www.djangoproject.com/"
+                                       target="_blank"
+                                       rel="noopener noreferrer">Django</a>.
+                                    Check out the source on
+                                    <a href="https://github.com/Metron-Project/metron"
+                                       target="_blank"
+                                       rel="noopener noreferrer">GitHub</a>
+                                    and help improve the platform.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="https://github.com/Metron-Project/metron"
+                               class="card-footer-item"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                <span class="icon"><i class="fab fa-github"></i></span>
+                                <span>View on GitHub</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-one-third-desktop">
+                    <div class="card home-community-card is-height-100">
+                        <div class="card-content has-text-centered">
+                            <span class="icon is-large home-feature-icon mb-3">
+                                <i class="fas fa-hand-holding-usd fa-2x"></i>
+                            </span>
+                            <p class="title is-5 mt-3">Support the Project</p>
+                            <div class="content">
+                                <p>
+                                    Help cover server and development costs by donating through
+                                    <a href="https://opencollective.com/metron"
+                                       target="_blank"
+                                       rel="noopener noreferrer">OpenCollective</a>.
+                                    Every contribution helps keep Metron running.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            <a href="https://opencollective.com/metron"
+                               class="card-footer-item"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                <span class="icon"><i class="fas fa-heart"></i></span>
+                                <span>Donate</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {# Contact / Questions #}
+            <div class="mt-6">
+                <h3 class="title is-4 has-text-centered">Have Questions?</h3>
+                <div class="columns is-centered">
+                    <div class="column is-8-desktop">
+                        <div class="box home-contact-box">
+                            <p class="has-text-centered mb-4">Feel free to reach out through any of these channels:</p>
+                            <div class="columns is-mobile is-centered">
+                                <div class="column has-text-centered">
+                                    <a href="https://matrix.to/#/#metrondb:matrix.org"
+                                       class="home-contact-link"
+                                       target="_blank"
+                                       rel="noopener noreferrer">
+                                        <span class="icon is-large home-feature-icon">
+                                            <i class="fas fa-comments fa-2x"></i>
+                                        </span>
+                                        <p class="mt-2">Matrix Chat</p>
+                                    </a>
+                                </div>
+                                <div class="column has-text-centered">
+                                    <a href="https://github.com/Metron-Project/metron/discussions"
+                                       class="home-contact-link"
+                                       target="_blank"
+                                       rel="noopener noreferrer">
+                                        <span class="icon is-large home-feature-icon">
+                                            <i class="fab fa-github fa-2x"></i>
+                                        </span>
+                                        <p class="mt-2">GitHub Discussions</p>
+                                    </a>
+                                </div>
+                                <div class="column has-text-centered">
+                                    <a href="mailto:admin@metron.cloud" class="home-contact-link">
+                                        <span class="icon is-large home-feature-icon">
+                                            <i class="fas fa-envelope fa-2x"></i>
+                                        </span>
+                                        <p class="mt-2">Email Admin</p>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/comicsdb/templates/comicsdb/home.html
+++ b/comicsdb/templates/comicsdb/home.html
@@ -154,9 +154,9 @@
                             </div>
                         </div>
                         <div class="card-footer">
-                            <a href="{% url 'signup' %}" class="card-footer-item">
-                                <span class="icon"><i class="fas fa-user-plus"></i></span>
-                                <span>Get Started</span>
+                            <a href="{% url 'user_collection:list' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-boxes"></i></span>
+                                <span>View Collection</span>
                             </a>
                         </div>
                     </div>
@@ -178,9 +178,9 @@
                             </div>
                         </div>
                         <div class="card-footer">
-                            <a href="{% url 'signup' %}" class="card-footer-item">
-                                <span class="icon"><i class="fas fa-user-plus"></i></span>
-                                <span>Get Started</span>
+                            <a href="{% url 'reading-list:list' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-tasks"></i></span>
+                                <span>View Reading Lists</span>
                             </a>
                         </div>
                     </div>
@@ -202,9 +202,9 @@
                             </div>
                         </div>
                         <div class="card-footer">
-                            <a href="{% url 'signup' %}" class="card-footer-item">
-                                <span class="icon"><i class="fas fa-user-plus"></i></span>
-                                <span>Get Started</span>
+                            <a href="{% url 'wish-list:detail' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-heart"></i></span>
+                                <span>View Wish List</span>
                             </a>
                         </div>
                     </div>
@@ -226,9 +226,9 @@
                             </div>
                         </div>
                         <div class="card-footer">
-                            <a href="{% url 'signup' %}" class="card-footer-item">
-                                <span class="icon"><i class="fas fa-user-plus"></i></span>
-                                <span>Get Started</span>
+                            <a href="{% url 'pull-list:detail' %}" class="card-footer-item">
+                                <span class="icon"><i class="fas fa-rss"></i></span>
+                                <span>View Pull List</span>
                             </a>
                         </div>
                     </div>

--- a/static/site/css/home/index.css
+++ b/static/site/css/home/index.css
@@ -16,6 +16,8 @@
 .home-hero {
     background: linear-gradient(150deg, hsl(217, 60%, 18%) 0%, hsl(217, 55%, 30%) 100%);
     color: #fff;
+    clip-path: polygon(0 0, 100% 0, 100% 88%, 0 100%);
+    padding-bottom: 4rem;
 }
 
 .home-hero-body {

--- a/static/site/css/home/index.css
+++ b/static/site/css/home/index.css
@@ -9,7 +9,146 @@
     }
 }
 
-/* Timeline styles for the home page */
+/* ========================================
+   Hero — Fedora-inspired large hero
+   ======================================== */
+
+.home-hero .hero-body {
+    padding: 5rem 1.5rem;
+}
+
+.hero-eyebrow {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    opacity: 0.75;
+}
+
+.hero-title {
+    font-size: 4rem !important;
+    font-weight: 800;
+    letter-spacing: -1px;
+}
+
+.hero-subtitle {
+    opacity: 0.9;
+    max-width: 480px;
+    margin-left: auto !important;
+    margin-right: auto !important;
+}
+
+@media screen and (max-width: 768px) {
+    .home-hero .hero-body {
+        padding: 3rem 1.5rem;
+    }
+
+    .hero-title {
+        font-size: 2.5rem !important;
+    }
+}
+
+/* ========================================
+   Section headings — centered with divider accent
+   ======================================== */
+
+.home-section-intro {
+    max-width: 600px;
+    margin-left: auto !important;
+    margin-right: auto !important;
+}
+
+.home-section-divider {
+    width: 60px;
+    height: 4px;
+    background-color: hsl(217, 71%, 53%);
+    border-radius: 2px;
+    margin: 1.5rem auto 0;
+}
+
+/* ========================================
+   Feature & community cards
+   ======================================== */
+
+.home-feature-card,
+.home-community-card {
+    border: 1px solid hsl(0, 0%, 90%);
+    border-radius: 8px;
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.home-feature-card:hover,
+.home-community-card:hover {
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    transform: translateY(-2px);
+}
+
+.home-feature-icon {
+    color: hsl(217, 71%, 53%);
+}
+
+.home-feature-card .card-footer,
+.home-community-card .card-footer {
+    border-top: 1px solid hsl(0, 0%, 93%);
+}
+
+.home-feature-card .card-footer-item,
+.home-community-card .card-footer-item {
+    font-weight: 500;
+    color: hsl(217, 71%, 53%);
+    gap: 0.4rem;
+    transition: background-color 0.15s ease;
+}
+
+.home-feature-card .card-footer-item:hover,
+.home-community-card .card-footer-item:hover {
+    background-color: hsla(217, 71%, 53%, 0.06);
+    text-decoration: none;
+}
+
+@media (prefers-color-scheme: dark) {
+    .home-feature-card,
+    .home-community-card {
+        border-color: hsl(0, 0%, 25%);
+    }
+
+    .home-feature-card .card-footer,
+    .home-community-card .card-footer {
+        border-top-color: hsl(0, 0%, 25%);
+    }
+}
+
+/* ========================================
+   About section
+   ======================================== */
+
+.home-about-content {
+    max-width: 800px;
+    margin: 0 auto;
+    font-size: 1.05rem;
+    line-height: 1.8;
+}
+
+/* ========================================
+   Contact box
+   ======================================== */
+
+.home-contact-link {
+    display: block;
+    color: inherit;
+    transition: color 0.15s ease, transform 0.15s ease;
+}
+
+.home-contact-link:hover {
+    color: hsl(217, 71%, 53%);
+    transform: translateY(-2px);
+    text-decoration: none;
+}
+
+/* ========================================
+   Timeline styles
+   ======================================== */
+
 #timeline {
     margin: 0 1em;
 }
@@ -34,12 +173,12 @@
     background-color: #3EB2EF;
     color: white;
     line-height: 31px;
-    border:none;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
-    transition: all 0.3s cubic-bezier(.25,.8,.25,1);
+    border: none;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
 }
 
 #timeline .mini-timeline i:hover {
-    box-shadow: 0 2px 5px rgba(0,0,0,0.16), 0 2px 5px rgba(0,0,0,0.23);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.16), 0 2px 5px rgba(0, 0, 0, 0.23);
     transform: scale(1.5);
 }

--- a/static/site/css/home/index.css
+++ b/static/site/css/home/index.css
@@ -10,41 +10,67 @@
 }
 
 /* ========================================
-   Hero — Fedora-inspired large hero
+   Hero — full-width, Fedora-inspired
    ======================================== */
 
-.home-hero .hero-body {
+.home-hero {
+    background: linear-gradient(150deg, hsl(217, 60%, 18%) 0%, hsl(217, 55%, 30%) 100%);
+    color: #fff;
+}
+
+.home-hero-body {
     padding: 5rem 1.5rem;
 }
 
-.hero-eyebrow {
+.home-hero-logo {
+    display: block;
+    margin: 0 auto 1.5rem;
+    filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.35));
+}
+
+.home-hero-title {
+    font-size: 4rem;
+    font-weight: 800;
+    letter-spacing: -1px;
+    color: #fff;
+    line-height: 1.1;
+}
+
+.home-hero-tagline {
     font-size: 0.8rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 3px;
-    opacity: 0.75;
+    opacity: 0.7;
+    margin-top: 0.5rem;
+    color: #fff;
 }
 
-.hero-title {
-    font-size: 4rem !important;
-    font-weight: 800;
-    letter-spacing: -1px;
-}
-
-.hero-subtitle {
-    opacity: 0.9;
+.home-hero-subtitle {
+    font-size: 1.25rem;
+    opacity: 0.85;
     max-width: 480px;
-    margin-left: auto !important;
-    margin-right: auto !important;
+    margin: 1rem auto 0;
+    color: #fff;
+    line-height: 1.6;
+}
+
+.home-hero-buttons {
+    margin-top: 2rem !important;
 }
 
 @media screen and (max-width: 768px) {
-    .home-hero .hero-body {
+    .home-hero-body {
         padding: 3rem 1.5rem;
     }
 
-    .hero-title {
-        font-size: 2.5rem !important;
+    .home-hero-title {
+        font-size: 2.5rem;
+    }
+
+    .home-hero-logo {
+        width: 80px;
+        height: 80px;
     }
 }
 

--- a/static/site/css/timeline/timeline.css
+++ b/static/site/css/timeline/timeline.css
@@ -250,18 +250,6 @@
     height: var(--icon-image-width);
 }
 
-/* Icons that use the pydis logo */
-.timeline-icon img.pydis {
-    /* Visually centering the pydis logo requires a margin adjustment here
-     * due to the right and bottom box shadow on the logo which is not very
-     * visible on the page.
-     *
-     * XXX: Hardcoded; Unresponsive to actual image dimensions.
-     * */
-    margin-top: 1px;
-    margin-left: 1px;
-}
-
 .timeline-date {
     font-size: .9rem;
     color: var(--date-color);

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,6 +44,8 @@
           hx-headers='{"x-csrftoken": "{{ csrf_token }}"}'>
         {# Navigation #}
         {% include "partials/navbar.html" %}
+        {# Full-width hero block (outside container, for pages like home) #}
+        {% block hero %}{% endblock %}
         {# Main Content #}
         <main id="main-content" class="section is-flex-grow-1">
             <div class="container">

--- a/timeline/entries/2025-11-04_add_wiki.md
+++ b/timeline/entries/2025-11-04_add_wiki.md
@@ -1,7 +1,7 @@
 ---
 title: Add wiki to site
 date: Nov 4th, 2025
-icon: fa fa-confluence
+icon: fas fa-book
 icon_color: pastel-purple
 ---
 

--- a/timeline/templates/timeline_entry.html
+++ b/timeline/templates/timeline_entry.html
@@ -7,11 +7,7 @@
      {% endif %}>
   <div class="timeline-icon-date">
     <div class="timeline-icon {{ entry.icon_color }}{% if not revealed %} timeline-icon--hidden{% else %} timeline-icon--bounce-in{% endif %}">
-      {% if entry.icon == "pydis" %}
-        <img class="pydis" src="{% static "images/timeline/cd-icon-pydis.svg" %}" alt="">
-      {% else %}
-        <span class="icon"><i class="{{ entry.icon }}"></i></span>
-      {% endif %}
+      <span class="icon"><i class="{{ entry.icon }}"></i></span>
     </div>
     <span class="timeline-date{% if not revealed %} timeline-date--hidden{% else %} timeline-date--bounce-in{% endif %}">{{ entry.date }}</span>
   </div>


### PR DESCRIPTION
## Summary

- Replace the home page hero stats row with CTA buttons (Browse Comics, Read the Wiki, Sign Up Free) and upgrade it to a medium-height hero
- Convert the feature sections from two-column text blocks into a card grid covering REST API, Collections, Reading Lists, Wish List, Pull List, and Quick Scrobble
- Replace the contribute/questions columns with a community card grid (Add Data, Contribute Code, Support the Project) and a contact box
- Fix three FA6 icon names that were broken under Font Awesome 5 Free: `fa-boxes-stacked` → `fa-boxes`, `fa-list-check` → `fa-tasks`, `fa-hand-holding-dollar` → `fa-hand-holding-usd`
- Fix the wiki timeline entry icon (`fa-confluence` → `fas fa-book`)
