### PR TITLE
Metron Issue templates Improvements

### DIFF
--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -39,9 +39,32 @@
                 hx-on:click="this.closest('.modal').classList.remove('is-active'); document.documentElement.classList.remove('is-clipped');">
         </button>
     </div>
+    {# Breadcrumb #}
+    <nav class="breadcrumb" aria-label="breadcrumbs">
+        <ul>
+            <li>
+                <a href="{% url 'publisher:detail' issue.series.publisher.slug %}">{{ issue.series.publisher }}</a>
+            </li>
+            <li>
+                <a href="{% url 'series:detail' issue.series.slug %}">{{ issue.series }}</a>
+            </li>
+            <li class="is-active">
+                <a href="#" aria-current="page">Issue #{{ issue.number }}</a>
+            </li>
+        </ul>
+    </nav>
     {# Page Header #}
     <header class="block">
-        <h1 class="title">{{ issue }}</h1>
+        <h1 class="title mb-2">{{ issue }}</h1>
+        <p class="subtitle is-5">
+            <a href="{% url 'series:detail' issue.series.slug %}">{{ issue.series }}</a>
+            <span class="has-text-grey">&middot;</span>
+            <time datetime="{{ issue.cover_date|date:'Y-m-d' }}" class="has-text-grey">{{ issue.cover_date|date:"M Y" }}</time>
+            {% if issue.rating.name and issue.rating.name != "Unknown" %}
+                <span class="tag is-warning is-light is-rounded ml-2"
+                      title="{{ issue.rating.short_description }}">{{ issue.rating.name }}</span>
+            {% endif %}
+        </p>
     </header>
     {# Navigation Bar #}
     <nav class="level mb-5" aria-label="Issue navigation">
@@ -179,7 +202,7 @@
         {# Left Column - Covers #}
         <div class="column is-one-quarter">
             {# Main Cover #}
-            <div class="box">
+            <div class="box issue-cover-sticky">
                 {% if issue.image %}
                     {% thumbnail issue.image "320x480" format="WEBP" as im %}
                         <figure class="image {% if im.width > im.height %}is-3by2{% else %}is-2by3{% endif %}">
@@ -610,21 +633,54 @@
                 <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ issue.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ issue.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ issue.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if issue.cv_id %}
                         <dt class="has-text-weight-bold">Comic Vine:</dt>
-                        <dd class="mb-2">
-                            {{ issue.cv_id }}
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/issue/4000-{{ issue.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ issue.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ issue.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if issue.gcd_id %}
                         <dt class="has-text-weight-bold">
                             <abbr title="Grand Comics Database">GCD</abbr>:
                         </dt>
-                        <dd>
-                            {{ issue.gcd_id }}
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/issue/{{ issue.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ issue.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ issue.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
@@ -632,3 +688,23 @@
         </div>
     </div>
 {% endblock content %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        // Show a quick feedback message
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => {
+                            this.innerHTML = originalText;
+                        }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
+{% endblock %}

--- a/comicsdb/templates/comicsdb/partials/issue_card_grid.html
+++ b/comicsdb/templates/comicsdb/partials/issue_card_grid.html
@@ -2,8 +2,13 @@
 {% load static %}
 {% load is_new %}
 {% comment %}
-    Issue-specific card grid with "New!" tags and cover date
+    Issue-specific card grid with "New!" tags, publisher, and cover date.
     Usage: {% include "comicsdb/partials/issue_card_grid.html" with items=issue_list %}
+
+    USABILITY CHANGE: the footer now shows the PUBLISHER + COVER DATE
+    instead of a redundant "Info" link. The whole cover already links to the
+    detail page, so the extra link added clicks-to-nowhere; the publisher is
+    far more useful context when scanning a grid of issues.
 {% endcomment %}
 <div class="columns is-multiline">
     {% for issue in items %}
@@ -45,16 +50,18 @@
                         </figure>
                     {% endif %}
                 </div>
-                {# Card Footer #}
+                {# Card Footer — publisher + cover date #}
                 <footer class="card-footer">
-                    <span class="card-footer-item">
+                    <span class="card-footer-item is-size-7"
+                          title="{{ issue.series.publisher }}"
+                          style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; text-align: center;">
+                        {{ issue.series.publisher }}
+                    </span>
+                    <span class="card-footer-item is-size-7 has-text-weight-semibold">
                         <time datetime="{{ issue.cover_date|date:'Y-m' }}">
                             {{ issue.cover_date|date:"M Y" }}
                         </time>
                     </span>
-                    <a href="{% url 'issue:detail' issue.slug %}"
-                       class="card-footer-item"
-                       aria-label="View information for {{ issue }}">Info</a>
                 </footer>
             </article>
         </div>

--- a/comicsdb/templates/comicsdb/partials/issue_filter.html
+++ b/comicsdb/templates/comicsdb/partials/issue_filter.html
@@ -1,4 +1,10 @@
 {% load range_tags %}
+{% comment %}
+    USABILITY CHANGE: the ~14 advanced filter fields are now organised
+    under labelled sub-sections (Series / Issue Numbers / Dates / Codes & IDs)
+    instead of a flat list separated by bare <hr> rules. Same fields, same
+    names, same values — purely a presentation regroup, no view changes needed.
+{% endcomment %}
 <div class="box mb-5" id="filter-panel">
     <form method="get" accept-charset="utf-8">
         <div class="is-flex is-justify-content-space-between is-align-items-center mb-4">
@@ -46,6 +52,9 @@
                     <span>Advanced Filters</span>
                 </span>
             </summary>
+
+            {# ── Group: Series ───────────────────────────────────────────── #}
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">Series</h4>
             <div class="columns is-multiline">
                 {# Series Name Filter #}
                 <div class="column is-half">
@@ -125,7 +134,11 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
+            </div>
+
+            {# ── Group: Issue Numbers ────────────────────────────────────── #}
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">Issue Numbers</h4>
+            <div class="columns is-multiline">
                 {# Issue Number Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -162,7 +175,11 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
+            </div>
+
+            {# ── Group: Dates ────────────────────────────────────────────── #}
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">Dates</h4>
+            <div class="columns is-multiline">
                 {# Cover Year Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -234,7 +251,6 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
                 {# Store Date From Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -303,7 +319,11 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
+            </div>
+
+            {# ── Group: Codes & IDs ──────────────────────────────────────── #}
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">Codes &amp; IDs</h4>
+            <div class="columns is-multiline">
                 {# UPC Code Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -340,7 +360,6 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
                 {# Comic Vine ID Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -429,6 +448,14 @@ details[open] > summary::before {
 
 details > summary:hover {
     color: hsl(217, 71%, 53%);
+}
+
+/* Group sub-headings inside the advanced panel */
+#filter-panel details h4.title {
+    border-bottom: 1px solid hsl(0, 0%, 93%);
+    padding-bottom: 0.4rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 }
 
 /* Mobile filter buttons styling */


### PR DESCRIPTION
## Changes

Template-only usability improvements to the **issue detail** and **issue list** views. No model, view, URL, or migration changes.

### Issue Detail
- **Breadcrumb** — Publisher › Series › Issue, for context + up-navigation.
- **Richer header** — series link, cover date, and a rating badge sit with the title instead of only in the far-right sidebar.
- **Identification Numbers** — Comic Vine / GCD become outbound links; every ID gets a copy-to-clipboard button.

### Issue List
- **Grouped advanced filters** (`partials/issue_filter.html`) — the ~14 fields organized under Series / Issue Numbers / Dates / Codes & IDs sub-headings instead of a flat `<hr>`-separated list. Same fields/names/values.
- **Richer cards** (`partials/issue_card_grid.html`) — footer shows publisher + cover date instead of a redundant "Info" link (the whole cover already links to the detail page).