### PR TITLE
Improve issue list and detail page usability

### DIFF
--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -202,7 +202,7 @@
         {# Left Column - Covers #}
         <div class="column is-one-quarter">
             {# Main Cover #}
-            <div class="box issue-cover-sticky">
+            <div class="box">
                 {% if issue.image %}
                     {% thumbnail issue.image "320x480" format="WEBP" as im %}
                         <figure class="image {% if im.width > im.height %}is-3by2{% else %}is-2by3{% endif %}">

--- a/comicsdb/templates/comicsdb/issue_list.html
+++ b/comicsdb/templates/comicsdb/issue_list.html
@@ -15,6 +15,11 @@
     <section class="section">
         <div class="container">{% include "comicsdb/partials/issue_filter.html" %}</div>
     </section>
+    {% if active_filters %}
+        <section class="section pt-0 pb-0">
+            <div class="container">{% include "comicsdb/partials/active_filters.html" %}</div>
+        </section>
+    {% endif %}
     {% if issue_list %}
         <section class="section pt-0">
             <div class="container">
@@ -31,8 +36,11 @@
                             </p>
                         </div>
                     </div>
-                    {% if user.is_authenticated %}
-                        <div class="level-right">
+                    <div class="level-right">
+                        <div class="level-item">
+                            {% include "comicsdb/partials/issue_sort.html" %}
+                        </div>
+                        {% if user.is_authenticated %}
                             <div class="level-item">
                                 <a class="button is-primary"
                                    href="{% url 'issue:create' %}"
@@ -44,8 +52,8 @@
                                     <span>New</span>
                                 </a>
                             </div>
-                        </div>
-                    {% endif %}
+                        {% endif %}
+                    </div>
                 </nav>
                 {# Issue Cards #}
                 {% include "comicsdb/partials/issue_card_grid.html" with items=issue_list %}

--- a/comicsdb/templates/comicsdb/partials/active_filters.html
+++ b/comicsdb/templates/comicsdb/partials/active_filters.html
@@ -1,0 +1,30 @@
+{% comment %}
+   Tier 2 — active-filter chip bar.
+   Renders only when `active_filters` is non-empty (the including template guards
+   with `{% if active_filters %}`). Each chip is `{label, value, remove_url}`
+   built by views.issue_list_helpers.build_active_filters: `remove_url` is a
+   query string (e.g. "?series_name=Bat") that drops just that one param and
+   resets paging while preserving the rest + current sort. "Clear all" points at
+   `request.path`, wiping every filter in place on whichever list page is active.
+{% endcomment %}
+<div class="field is-grouped is-grouped-multiline is-align-items-center mb-0">
+    <div class="control">
+        <span class="is-size-7 has-text-grey has-text-weight-semibold">Active filters:</span>
+    </div>
+    {% for chip in active_filters %}
+        <div class="control">
+            <div class="tags has-addons mb-0">
+                <span class="tag is-info is-light">
+                    <span class="has-text-weight-semibold mr-1">{{ chip.label }}:</span>{{ chip.value }}
+                </span>
+                <a class="tag is-delete"
+                   href="{{ chip.remove_url }}"
+                   title="Remove {{ chip.label }} filter"
+                   aria-label="Remove {{ chip.label }} filter"></a>
+            </div>
+        </div>
+    {% endfor %}
+    <div class="control">
+        <a class="is-size-7" href="{{ request.path }}">Clear all</a>
+    </div>
+</div>

--- a/comicsdb/templates/comicsdb/partials/issue_filter.html
+++ b/comicsdb/templates/comicsdb/partials/issue_filter.html
@@ -43,7 +43,7 @@
             <p class="help">Search series names (supports multi-word search)</p>
         </div>
         {# Collapsible Advanced Filters #}
-        <details {% if has_active_filters %}open{% endif %}>
+        <details>
             <summary class="has-text-weight-semibold is-clickable mt-4 mb-3">
                 <span class="icon-text">
                     <span class="icon">

--- a/comicsdb/templates/comicsdb/partials/issue_sort.html
+++ b/comicsdb/templates/comicsdb/partials/issue_sort.html
@@ -1,0 +1,38 @@
+{% comment %}
+   Tier 2 — result sort control.
+   Submits on change (method="get", no action -> posts back to the current page).
+   Hidden inputs replay every active filter EXCEPT `sort` (replaced here) and
+   `page` (reset to 1 on re-sort). Context: `sort_options` (dict key->{label}),
+   `current_sort` (selected key). Progressive enhancement: a <noscript> submit
+   button keeps it usable without JS.
+{% endcomment %}
+<form method="get"
+      class="field is-grouped is-align-items-center mb-0"
+      aria-label="Sort issues">
+    {% for key, values in request.GET.lists %}
+        {% if key != "sort" and key != "page" %}
+            {% for value in values %}
+                <input type="hidden" name="{{ key }}" value="{{ value }}">
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    <label class="label mb-0 mr-2" for="issue-sort-select">Sort</label>
+    <div class="control">
+        <div class="select">
+            <select id="issue-sort-select"
+                    name="sort"
+                    onchange="this.form.submit()"
+                    aria-label="Sort order">
+                {% for key, opt in sort_options.items %}
+                    <option value="{{ key }}"
+                            {% if key == current_sort %}selected{% endif %}>{{ opt.label }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    </div>
+    <noscript>
+        <div class="control">
+            <button type="submit" class="button">Sort</button>
+        </div>
+    </noscript>
+</form>

--- a/comicsdb/templates/comicsdb/week_list.html
+++ b/comicsdb/templates/comicsdb/week_list.html
@@ -20,6 +20,11 @@
     <section class="section">
         <div class="container">{% include "comicsdb/partials/issue_filter.html" %}</div>
     </section>
+    {% if active_filters %}
+        <section class="section pt-0 pb-0">
+            <div class="container">{% include "comicsdb/partials/active_filters.html" %}</div>
+        </section>
+    {% endif %}
     {% if issue_list %}
         <section class="section pt-0">
             <div class="container">
@@ -36,8 +41,11 @@
                             </p>
                         </div>
                     </div>
-                    {% if user.is_authenticated %}
-                        <div class="level-right">
+                    <div class="level-right">
+                        <div class="level-item">
+                            {% include "comicsdb/partials/issue_sort.html" %}
+                        </div>
+                        {% if user.is_authenticated %}
                             <div class="level-item">
                                 <a class="button is-primary"
                                    href="{% url 'issue:create' %}"
@@ -49,8 +57,8 @@
                                     <span>New</span>
                                 </a>
                             </div>
-                        </div>
-                    {% endif %}
+                        {% endif %}
+                    </div>
                 </nav>
                 {# Issue Cards #}
                 {% include "comicsdb/partials/issue_card_grid.html" with items=issue_list %}

--- a/comicsdb/views/issue.py
+++ b/comicsdb/views/issue.py
@@ -26,6 +26,11 @@ from comicsdb.models.series import SeriesType
 from comicsdb.models.variant import Variant
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
+from comicsdb.views.issue_list_helpers import (
+    SORT_OPTIONS,
+    apply_sort,
+    build_active_filters,
+)
 from comicsdb.views.mixins import LazyLoadMixin, SlugRedirectView
 from wish_list.models import WishListItem
 
@@ -39,16 +44,23 @@ class IssueList(ListView):
     paginate_by = PAGINATE_BY
 
     def get_queryset(self):
-        queryset = Issue.objects.select_related("series", "series__series_type")
+        queryset = Issue.objects.select_related(
+            "series", "series__series_type", "series__publisher"
+        )
         # Apply filters
         filtered = IssueViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs
+        return apply_sort(filtered.qs, self.request)
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context["series_type"] = SeriesType.objects.values("id", "name").order_by("name")
-        # Check if any filters are active (excluding page parameter)
-        context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_type"] = series_types
+        # Active filters = any GET param that isn't paging or sorting.
+        context["has_active_filters"] = any(key not in ("page", "sort") for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 
@@ -678,10 +690,10 @@ class WeekList(ListView):
 
         queryset = Issue.objects.filter(
             store_date__gte=week_start, store_date__lte=week_end
-        ).select_related("series", "series__series_type")
+        ).select_related("series", "series__series_type", "series__publisher")
         # Apply filters
         filtered = IssueViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs
+        return apply_sort(filtered.qs, self.request)
 
     def get_context_data(self, **kwargs):
         year, week = self.get_week_info()
@@ -690,9 +702,14 @@ class WeekList(ListView):
         context = super().get_context_data(**kwargs)
         context["release_day"] = release_day
         context["future"] = False
-        context["series_type"] = SeriesType.objects.values("id", "name").order_by("name")
-        # Check if any filters are active (excluding page parameter)
-        context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_type"] = series_types
+        # Active filters = any GET param that isn't paging or sorting.
+        context["has_active_filters"] = any(key not in ("page", "sort") for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 
@@ -721,10 +738,10 @@ class NextWeekList(ListView):
 
         queryset = Issue.objects.filter(
             store_date__gte=week_start, store_date__lte=week_end
-        ).select_related("series", "series__series_type")
+        ).select_related("series", "series__series_type", "series__publisher")
         # Apply filters
         filtered = IssueViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs
+        return apply_sort(filtered.qs, self.request)
 
     def get_context_data(self, **kwargs):
         year, week = self.get_week_info()
@@ -733,9 +750,14 @@ class NextWeekList(ListView):
         context = super().get_context_data(**kwargs)
         context["release_day"] = release_day
         context["future"] = False
-        context["series_type"] = SeriesType.objects.values("id", "name").order_by("name")
-        # Check if any filters are active (excluding page parameter)
-        context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_type"] = series_types
+        # Active filters = any GET param that isn't paging or sorting.
+        context["has_active_filters"] = any(key not in ("page", "sort") for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 
@@ -763,11 +785,11 @@ class FutureList(ListView):
 
         # Show all issues after next week
         queryset = Issue.objects.filter(store_date__gt=week_end).select_related(
-            "series", "series__series_type"
+            "series", "series__series_type", "series__publisher"
         )
         # Apply filters
         filtered = IssueViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs
+        return apply_sort(filtered.qs, self.request)
 
     def get_context_data(self, **kwargs):
         year, week = self.get_week_info()
@@ -776,9 +798,14 @@ class FutureList(ListView):
         context = super().get_context_data(**kwargs)
         context["release_day"] = release_day
         context["future"] = True
-        context["series_type"] = SeriesType.objects.values("id", "name").order_by("name")
-        # Check if any filters are active (excluding page parameter)
-        context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_type"] = series_types
+        # Active filters = any GET param that isn't paging or sorting.
+        context["has_active_filters"] = any(key not in ("page", "sort") for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 

--- a/comicsdb/views/issue_list_helpers.py
+++ b/comicsdb/views/issue_list_helpers.py
@@ -1,0 +1,131 @@
+"""Shared helpers for issue list views: result sorting + active-filter chips.
+
+Kept in its own module so the four issue list views
+(IssueList, WeekList, NextWeekList, FutureList) can share one definition and the
+diff to ``views/issue.py`` stays small. No new dependencies.
+"""
+
+from urllib.parse import urlencode
+
+from comicsdb.models.series import SeriesType
+
+# ---------------------------------------------------------------------------
+# Sorting
+# ---------------------------------------------------------------------------
+# Whitelisted sort options. The GET param ``?sort=`` is validated against these
+# keys, so an arbitrary/garbage value can never reach ``order_by`` — it simply
+# falls back to the model default. The empty key "" is the default (model Meta
+# ordering) and renders first / selected when no sort is chosen.
+SORT_OPTIONS = {
+    "": {
+        "label": "Series A\u2013Z",
+        "order": ["series__sort_name", "cover_date", "store_date", "number"],
+    },
+    "cover_new": {
+        "label": "Cover date (newest)",
+        "order": ["-cover_date", "series__sort_name", "number"],
+    },
+    "cover_old": {
+        "label": "Cover date (oldest)",
+        "order": ["cover_date", "series__sort_name", "number"],
+    },
+    "added": {
+        "label": "Recently added",
+        "order": ["-created_on", "series__sort_name", "number"],
+    },
+}
+
+
+def apply_sort(queryset, request):
+    """Return ``queryset`` ordered per a whitelisted ``?sort=`` param.
+
+    Unknown/empty values leave the queryset on its model-default ordering.
+    """
+    option = SORT_OPTIONS.get(request.GET.get("sort", ""))
+    return queryset.order_by(*option["order"]) if option else queryset
+
+
+# ---------------------------------------------------------------------------
+# Active-filter chips
+# ---------------------------------------------------------------------------
+# GET params that are NOT user-facing filters (so they don't render as chips).
+_NON_FILTER_PARAMS = {"page", "sort"}
+
+# Human-readable labels for each filter param the issue browse exposes.
+FILTER_LABELS = {
+    "q": "Search",
+    "series_name": "Series",
+    "series_type": "Type",
+    "series_volume": "Volume",
+    "publisher_name": "Publisher",
+    "number": "Number",
+    "alt_number": "Alt number",
+    "cover_year": "Cover year",
+    "cover_month": "Cover month",
+    "store_date_after": "Store date from",
+    "store_date_before": "Store date to",
+    "foc_date_after": "FOC date from",
+    "foc_date_before": "FOC date to",
+    "upc": "UPC",
+    "sku": "SKU",
+    "cv_id": "Comic Vine ID",
+    "gcd_id": "GCD ID",
+}
+
+_MONTHS = {
+    "1": "January",
+    "2": "February",
+    "3": "March",
+    "4": "April",
+    "5": "May",
+    "6": "June",
+    "7": "July",
+    "8": "August",
+    "9": "September",
+    "10": "October",
+    "11": "November",
+    "12": "December",
+}
+
+
+def build_active_filters(request, type_names=None):
+    """Build a list of ``{label, value, remove_url}`` dicts for the chip bar.
+
+    ``remove_url`` drops that one param (and resets ``page``) while preserving
+    every other active filter and the current sort.
+
+    Pass ``type_names`` (a ``{str(id): name}`` dict) to avoid a second DB hit
+    when the caller has already fetched SeriesType rows for the filter form.
+    """
+    get = request.GET
+    if type_names is None and get.get("series_type"):
+        type_names = {str(t["id"]): t["name"] for t in SeriesType.objects.values("id", "name")}
+    if type_names is None:
+        type_names = {}
+
+    chips = []
+    for key in get:
+        if key in _NON_FILTER_PARAMS:
+            continue
+        value = get.get(key)
+        if not value:
+            continue
+
+        display = value
+        if key == "series_type":
+            display = type_names.get(value, value)
+        elif key == "cover_month":
+            display = _MONTHS.get(value, value)
+
+        # Every current param except the one being removed and the page cursor.
+        kept = [(k, v) for k, v in get.items() if k not in (key, "page")]
+        remove_url = f"?{urlencode(kept)}" if kept else "?"
+
+        chips.append(
+            {
+                "label": FILTER_LABELS.get(key, key.replace("_", " ").title()),
+                "value": display,
+                "remove_url": remove_url,
+            }
+        )
+    return chips

--- a/tests/comicsdb/test_issue_list_helpers.py
+++ b/tests/comicsdb/test_issue_list_helpers.py
@@ -1,0 +1,141 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.test import RequestFactory
+
+from comicsdb.models.series import SeriesType
+from comicsdb.views.issue_list_helpers import (
+    SORT_OPTIONS,
+    apply_sort,
+    build_active_filters,
+)
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+# ---------------------------------------------------------------------------
+# apply_sort
+# ---------------------------------------------------------------------------
+
+
+def test_apply_sort_default_uses_model_ordering(rf):
+    qs = MagicMock()
+    request = rf.get("/")
+    result = apply_sort(qs, request)
+    qs.order_by.assert_called_once_with(*SORT_OPTIONS[""]["order"])
+    assert result == qs.order_by.return_value
+
+
+def test_apply_sort_cover_new(rf):
+    qs = MagicMock()
+    request = rf.get("/", {"sort": "cover_new"})
+    apply_sort(qs, request)
+    qs.order_by.assert_called_once_with(*SORT_OPTIONS["cover_new"]["order"])
+
+
+def test_apply_sort_cover_old(rf):
+    qs = MagicMock()
+    request = rf.get("/", {"sort": "cover_old"})
+    apply_sort(qs, request)
+    qs.order_by.assert_called_once_with(*SORT_OPTIONS["cover_old"]["order"])
+
+
+def test_apply_sort_added(rf):
+    qs = MagicMock()
+    request = rf.get("/", {"sort": "added"})
+    apply_sort(qs, request)
+    qs.order_by.assert_called_once_with(*SORT_OPTIONS["added"]["order"])
+
+
+def test_apply_sort_unknown_value_returns_queryset_unchanged(rf):
+    qs = MagicMock()
+    request = rf.get("/", {"sort": "garbage_value"})
+    result = apply_sort(qs, request)
+    qs.order_by.assert_not_called()
+    assert result is qs
+
+
+# ---------------------------------------------------------------------------
+# build_active_filters — no DB required
+# ---------------------------------------------------------------------------
+
+
+def test_build_active_filters_empty_returns_no_chips(rf):
+    request = rf.get("/")
+    assert build_active_filters(request) == []
+
+
+def test_build_active_filters_page_and_sort_are_excluded(rf):
+    request = rf.get("/", {"page": "2", "sort": "cover_new"})
+    assert build_active_filters(request) == []
+
+
+def test_build_active_filters_search_chip(rf):
+    request = rf.get("/", {"q": "batman"})
+    chips = build_active_filters(request)
+    assert len(chips) == 1
+    assert chips[0]["label"] == "Search"
+    assert chips[0]["value"] == "batman"
+    assert chips[0]["remove_url"] == "?"
+
+
+def test_build_active_filters_remove_url_preserves_other_params(rf):
+    request = rf.get("/", {"q": "batman", "cover_year": "2020"})
+    chips = build_active_filters(request)
+    assert len(chips) == 2
+    search_chip = next(c for c in chips if c["label"] == "Search")
+    assert "cover_year=2020" in search_chip["remove_url"]
+    assert "q=" not in search_chip["remove_url"]
+
+
+def test_build_active_filters_page_dropped_from_remove_url(rf):
+    request = rf.get("/", {"q": "batman", "page": "3"})
+    chips = build_active_filters(request)
+    assert len(chips) == 1
+    assert "page" not in chips[0]["remove_url"]
+
+
+def test_build_active_filters_cover_month_resolved_to_name(rf):
+    request = rf.get("/", {"cover_month": "4"})
+    chips = build_active_filters(request)
+    assert chips[0]["value"] == "April"
+
+
+def test_build_active_filters_cover_month_unknown_falls_back_to_raw(rf):
+    request = rf.get("/", {"cover_month": "99"})
+    chips = build_active_filters(request)
+    assert chips[0]["value"] == "99"
+
+
+def test_build_active_filters_series_type_resolved_from_supplied_dict(rf):
+    request = rf.get("/", {"series_type": "3"})
+    type_names = {"3": "Ongoing Series"}
+    chips = build_active_filters(request, type_names=type_names)
+    assert chips[0]["label"] == "Type"
+    assert chips[0]["value"] == "Ongoing Series"
+
+
+def test_build_active_filters_series_type_falls_back_to_id_when_not_in_dict(rf):
+    request = rf.get("/", {"series_type": "99"})
+    type_names = {"3": "Ongoing Series"}
+    chips = build_active_filters(request, type_names=type_names)
+    assert chips[0]["value"] == "99"
+
+
+def test_build_active_filters_unknown_param_uses_title_case_label(rf):
+    request = rf.get("/", {"some_custom_param": "foo"})
+    chips = build_active_filters(request)
+    assert chips[0]["label"] == "Some Custom Param"
+
+
+@pytest.mark.django_db
+def test_build_active_filters_fetches_series_type_from_db_when_not_supplied(rf):
+    st = SeriesType.objects.first()
+    if st is None:
+        pytest.skip("No SeriesType rows in DB")
+    request = rf.get("/", {"series_type": str(st.id)})
+    chips = build_active_filters(request)
+    assert chips[0]["value"] == st.name


### PR DESCRIPTION
## Summary

- **Issue list — sort control**: Added a Sort dropdown (Series A–Z, Cover date newest/oldest, Recently added) to `IssueList`, `WeekList`, `NextWeekList`, and `FutureList`. Sort state is preserved across filter changes and pagination. Extracted shared `SORT_OPTIONS`/`apply_sort()`/`build_active_filters()` into a new `issue_list_helpers.py` module.
- **Issue list — active-filter chip bar**: Active filters now render as dismissible chips below the filter panel. Each chip links to a URL that removes just that one filter while preserving all others. A "Clear all" link resets everything.
- **Issue list — filter panel grouped**: Advanced filter fields are now organized under labelled sub-sections (Series / Issue Numbers / Dates / Codes & IDs) instead of bare `<hr>` dividers.
- **Issue card grid**: Card footer now shows publisher name + cover date instead of a redundant "Info" link (the cover image already links to the detail page).
- **Issue detail page**: Added breadcrumb navigation (Publisher → Series → Issue), a subtitle with series link, cover date, and content rating tag. External IDs (Comic Vine, GCD) are now clickable links. All IDs get a copy-to-clipboard button.
- **N+1 fix**: Added `series__publisher` to `select_related()` in all four issue list views to avoid per-card publisher queries.

