### PR TITLE
Improve Resource Pages Usability

### DIFF
--- a/comicsdb/autocomplete.py
+++ b/comicsdb/autocomplete.py
@@ -8,6 +8,7 @@ from autocomplete import ModelAutocomplete, register
 from django.db.models import Q
 
 from comicsdb.models import Arc, Character, Creator, Publisher, Series, Team, Universe
+from comicsdb.models.credits import Role
 from comicsdb.models.imprint import Imprint
 from comicsdb.models.issue import Issue
 
@@ -85,6 +86,26 @@ class CreatorAutocomplete(ModelAutocomplete):
             Q(name__unaccent__icontains=search),
             Q(alias__icontains=search),
         ]
+        condition_filter = reduce(operator.or_, conditions)
+        return queryset.filter(condition_filter)
+
+    @classmethod
+    def get_label_for_record(cls, record):
+        """Format the display name for autocomplete results."""
+        return str(record)
+
+
+class RoleAutocomplete(ModelAutocomplete):
+    """Autocomplete for searching creator roles."""
+
+    model = Role
+    search_attrs = ["name"]
+
+    @classmethod
+    def get_query_filtered_queryset(cls, search, context):
+        """Filter roles by name."""
+        queryset = cls.get_queryset()
+        conditions = [Q(**{f"{attr}__icontains": search}) for attr in cls.get_search_attrs()]
         condition_filter = reduce(operator.or_, conditions)
         return queryset.filter(condition_filter)
 
@@ -312,6 +333,7 @@ register(CreatorAutocomplete)
 register(ImprintAutocomplete)
 register(IssueAutocomplete)
 register(PublisherAutocomplete)
+register(RoleAutocomplete)
 register(SeriesAutocomplete)
 register(TeamAutocomplete)
 register(UniverseAutocomplete)

--- a/comicsdb/forms/credits.py
+++ b/comicsdb/forms/credits.py
@@ -1,8 +1,14 @@
-from django.forms import ModelChoiceField, ModelForm, SelectMultiple, inlineformset_factory
+from django.forms import (
+    ModelChoiceField,
+    ModelForm,
+    ModelMultipleChoiceField,
+    inlineformset_factory,
+)
 
-from comicsdb.autocomplete import CreatorAutocomplete
+from comicsdb.autocomplete import CreatorAutocomplete, RoleAutocomplete
 from comicsdb.forms.widgets import SafeAutocompleteWidget
 from comicsdb.models import Creator, Credits, Issue
+from comicsdb.models.credits import Role
 
 
 class CreditsForm(ModelForm):
@@ -15,11 +21,18 @@ class CreditsForm(ModelForm):
             },
         ),
     )
+    role = ModelMultipleChoiceField(
+        queryset=Role.objects.all(),
+        widget=SafeAutocompleteWidget(
+            ac_class=RoleAutocomplete,
+            attrs={"class": "input"},
+            options={"multiselect": True},
+        ),
+    )
 
     class Meta:
         model = Credits
         fields = ["issue", "creator", "role"]
-        widgets = {"role": SelectMultiple(attrs={"size": 5})}
 
 
 CreditsFormSet = inlineformset_factory(Issue, Credits, form=CreditsForm, extra=1, can_delete=True)

--- a/comicsdb/templates/comicsdb/arc_detail.html
+++ b/comicsdb/templates/comicsdb/arc_detail.html
@@ -176,24 +176,82 @@
                     <dd class="mb-3">
                         {{ arc.issue_count }}
                     </dd>
-                    <dt class="has-text-weight-bold">Metron ID:</dt>
-                    <dd class="mb-3">
-                        {{ arc.id }}
+                </dl>
+            </div>
+            {# Identification Numbers #}
+            <div class="box">
+                <h2 class="title is-6">Identification Numbers</h2>
+                <dl>
+                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ arc.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ arc.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if arc.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine ID:</dt>
-                        <dd class="mb-3">
-                            {{ arc.cv_id }}
+                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/story-arc/4045-{{ arc.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ arc.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ arc.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if arc.gcd_id %}
-                        <dt class="has-text-weight-bold">GCD ID:</dt>
-                        <dd>
-                            {{ arc.gcd_id }}
+                        <dt class="has-text-weight-bold">
+                            <abbr title="Grand Comics Database">GCD</abbr>:
+                        </dt>
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/story_arc/{{ arc.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ arc.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ arc.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
             </div>
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => { this.innerHTML = originalText; }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/character_detail.html
+++ b/comicsdb/templates/comicsdb/character_detail.html
@@ -245,27 +245,81 @@
                         </ul>
                     {% endif %}
                 {% endwith %}
-                {# IDs #}
-                <h3 class="title is-6 mt-4">Identification Numbers</h3>
+            </div>
+            {# Identification Numbers #}
+            <div class="box">
+                <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ character.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ character.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ character.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if character.cv_id %}
                         <dt class="has-text-weight-bold">Comic Vine:</dt>
-                        <dd class="mb-2">
-                            {{ character.cv_id }}
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/character/4005-{{ character.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ character.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ character.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if character.gcd_id %}
-                        <dt class="has-text-weight-bold">GCD:</dt>
-                        <dd>
-                            {{ character.gcd_id }}
+                        <dt class="has-text-weight-bold">
+                            <abbr title="Grand Comics Database">GCD</abbr>:
+                        </dt>
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/character/{{ character.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ character.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ character.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
             </div>
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => { this.innerHTML = originalText; }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/creator_detail.html
+++ b/comicsdb/templates/comicsdb/creator_detail.html
@@ -210,27 +210,81 @@
                         </dd>
                     {% endif %}
                 </dl>
-                {# IDs #}
-                <h3 class="title is-6 mt-4">Identification Numbers</h3>
+            </div>
+            {# Identification Numbers #}
+            <div class="box">
+                <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ creator.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ creator.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ creator.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if creator.cv_id %}
                         <dt class="has-text-weight-bold">Comic Vine:</dt>
-                        <dd class="mb-2">
-                            {{ creator.cv_id }}
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/person/4040-{{ creator.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ creator.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ creator.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if creator.gcd_id %}
-                        <dt class="has-text-weight-bold">GCD:</dt>
-                        <dd>
-                            {{ creator.gcd_id }}
+                        <dt class="has-text-weight-bold">
+                            <abbr title="Grand Comics Database">GCD</abbr>:
+                        </dt>
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/creator/{{ creator.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ creator.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ creator.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
             </div>
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => { this.innerHTML = originalText; }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/imprint_detail.html
+++ b/comicsdb/templates/comicsdb/imprint_detail.html
@@ -166,27 +166,81 @@
                         </dd>
                     {% endif %}
                 </dl>
-                {# IDs #}
-                <h3 class="title is-6 mt-4">Identification Numbers</h3>
+            </div>
+            {# Identification Numbers #}
+            <div class="box">
+                <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ imprint.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ imprint.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ imprint.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if imprint.cv_id %}
                         <dt class="has-text-weight-bold">Comic Vine:</dt>
-                        <dd class="mb-2">
-                            {{ imprint.cv_id }}
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/publisher/4010-{{ imprint.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ imprint.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ imprint.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if imprint.gcd_id %}
-                        <dt class="has-text-weight-bold">GCD:</dt>
-                        <dd>
-                            {{ imprint.gcd_id }}
+                        <dt class="has-text-weight-bold">
+                            <abbr title="Grand Comics Database">GCD</abbr>:
+                        </dt>
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/brand_group/{{ imprint.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ imprint.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ imprint.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
             </div>
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => { this.innerHTML = originalText; }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -39,9 +39,32 @@
                 hx-on:click="this.closest('.modal').classList.remove('is-active'); document.documentElement.classList.remove('is-clipped');">
         </button>
     </div>
+    {# Breadcrumb #}
+    <nav class="breadcrumb" aria-label="breadcrumbs">
+        <ul>
+            <li>
+                <a href="{% url 'publisher:detail' issue.series.publisher.slug %}">{{ issue.series.publisher }}</a>
+            </li>
+            <li>
+                <a href="{% url 'series:detail' issue.series.slug %}">{{ issue.series }}</a>
+            </li>
+            <li class="is-active">
+                <a href="#" aria-current="page">Issue #{{ issue.number }}</a>
+            </li>
+        </ul>
+    </nav>
     {# Page Header #}
     <header class="block">
-        <h1 class="title">{{ issue }}</h1>
+        <h1 class="title mb-2">{{ issue }}</h1>
+        <p class="subtitle is-5">
+            <a href="{% url 'series:detail' issue.series.slug %}">{{ issue.series }}</a>
+            <span class="has-text-grey">&middot;</span>
+            <time datetime="{{ issue.cover_date|date:'Y-m-d' }}" class="has-text-grey">{{ issue.cover_date|date:"M Y" }}</time>
+            {% if issue.rating.name and issue.rating.name != "Unknown" %}
+                <span class="tag is-warning is-light is-rounded ml-2"
+                      title="{{ issue.rating.short_description }}">{{ issue.rating.name }}</span>
+            {% endif %}
+        </p>
     </header>
     {# Navigation Bar #}
     <nav class="level mb-5" aria-label="Issue navigation">
@@ -179,7 +202,7 @@
         {# Left Column - Covers #}
         <div class="column is-one-quarter">
             {# Main Cover #}
-            <div class="box">
+            <div class="box issue-cover-sticky">
                 {% if issue.image %}
                     {% thumbnail issue.image "320x480" format="WEBP" as im %}
                         <figure class="image {% if im.width > im.height %}is-3by2{% else %}is-2by3{% endif %}">
@@ -610,21 +633,54 @@
                 <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ issue.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ issue.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ issue.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if issue.cv_id %}
                         <dt class="has-text-weight-bold">Comic Vine:</dt>
-                        <dd class="mb-2">
-                            {{ issue.cv_id }}
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/issue/4000-{{ issue.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ issue.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ issue.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if issue.gcd_id %}
                         <dt class="has-text-weight-bold">
                             <abbr title="Grand Comics Database">GCD</abbr>:
                         </dt>
-                        <dd>
-                            {{ issue.gcd_id }}
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/issue/{{ issue.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ issue.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ issue.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
@@ -632,3 +688,23 @@
         </div>
     </div>
 {% endblock content %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        // Show a quick feedback message
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => {
+                            this.innerHTML = originalText;
+                        }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
+{% endblock %}

--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -202,7 +202,7 @@
         {# Left Column - Covers #}
         <div class="column is-one-quarter">
             {# Main Cover #}
-            <div class="box issue-cover-sticky">
+            <div class="box">
                 {% if issue.image %}
                     {% thumbnail issue.image "320x480" format="WEBP" as im %}
                         <figure class="image {% if im.width > im.height %}is-3by2{% else %}is-2by3{% endif %}">

--- a/comicsdb/templates/comicsdb/issue_form.html
+++ b/comicsdb/templates/comicsdb/issue_form.html
@@ -8,47 +8,104 @@
     {{ form.media.css }}
     <link rel="stylesheet"
           href="{% static 'site/css/bulma-calendar.min.css' %}">
+    {# Sticky bar, section nav, grouped fields #}
+    <link rel="stylesheet"
+          href="{% static 'site/css/issue-form-usability.css' %}">
 {% endblock %}
 {% block content %}
-    <header class="block has-text-centered">
-        <h1 class="title">Issue Form</h1>
-    </header>
     <form method="post" enctype="multipart/form-data" id="issueForm" novalidate>
         {% csrf_token %}
+        <!-- Sticky action bar — Save / Cancel always reachable + section nav -->
+        <div class="usab-actionbar">
+            <div class="usab-actionbar__top">
+                <h1 class="usab-actionbar__title">Issue Form</h1>
+                <div class="usab-actionbar__actions">
+                    <button type="button" class="button" onclick="history.back()">
+                        <span class="icon"><i class="fas fa-times"></i></span>
+                        <span>Cancel</span>
+                    </button>
+                    <button class="button is-info" type="submit">
+                        <span class="icon"><i class="fas fa-check"></i></span>
+                        <span>Save Issue</span>
+                    </button>
+                </div>
+            </div>
+            <nav class="usab-nav" aria-label="Form sections">
+                <a href="#section-primary" class="is-active">Primary</a>
+                <a href="#section-credits">Credits</a>
+                <a href="#section-variants">Variants</a>
+                <a href="#section-attribution">Attribution</a>
+            </nav>
+        </div>
         <!-- Primary Information Section -->
-        <div class="box">
+        <div class="box" id="section-primary">
             <h2 class="title is-5">Primary Information</h2>
             {% include "comicsdb/partials/form_errors.html" with form=form %}
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}
-            {% for field in form.visible_fields %}
-                {% include "comicsdb/partials/form_field.html" with field=field %}
-            {% endfor %}
+
+            <div class="usab-group">
+                <h3 class="usab-group-label">Identity</h3>
+                <div class="columns is-multiline">
+                    <div class="column is-full">{% include "comicsdb/partials/form_field.html" with field=form.series %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.number %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.alt_number %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.rating %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.title %}</div>
+                    <div class="column is-full">{% include "comicsdb/partials/form_field.html" with field=form.name %}</div>
+                    <div class="column is-full">{% include "comicsdb/partials/form_field.html" with field=form.desc %}</div>
+                </div>
+            </div>
+
+            <div class="usab-group">
+                <h3 class="usab-group-label">Publication</h3>
+                <div class="columns is-multiline">
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.cover_date %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.store_date %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.foc_date %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.price %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.page %}</div>
+                </div>
+            </div>
+
+            <div class="usab-group">
+                <h3 class="usab-group-label">Codes &amp; IDs</h3>
+                <div class="columns is-multiline">
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.sku %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.isbn %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.upc %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.cv_id %}</div>
+                    <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.gcd_id %}</div>
+                </div>
+            </div>
+
+            <div class="usab-group">
+                <h3 class="usab-group-label">Cover Image</h3>
+                {% include "comicsdb/partials/form_field.html" with field=form.image %}
+            </div>
+
+            <div class="usab-group">
+                <h3 class="usab-group-label">Relationships</h3>
+                {% include "comicsdb/partials/form_field.html" with field=form.characters %}
+                {% include "comicsdb/partials/form_field.html" with field=form.teams %}
+                {% include "comicsdb/partials/form_field.html" with field=form.arcs %}
+                {% include "comicsdb/partials/form_field.html" with field=form.universes %}
+                {% include "comicsdb/partials/form_field.html" with field=form.reprints %}
+            </div>
         </div>
         <!-- Credits Section -->
-        <div class="box">
+        <div class="box" id="section-credits">
             <h2 class="title is-5">Credits</h2>
             {% include "comicsdb/partials/credits_formset.html" with formset=credits %}
         </div>
         <!-- Variant Covers Section -->
-        <div class="box">
+        <div class="box" id="section-variants">
             <h2 class="title is-5">Variant Covers</h2>
             {% include "comicsdb/partials/variants_formset.html" with formset=variants %}
         </div>
         <!-- Attribution Section -->
-        <div class="box">
+        <div class="box" id="section-attribution">
             <h2 class="title is-5">Attribution</h2>
             {% include "comicsdb/partials/attribution_formset.html" with formset=attribution %}
-        </div>
-        <!-- Submit Button -->
-        <div class="field">
-            <div class="control">
-                <button class="button is-info" type="submit">
-                    <span class="icon">
-                        <i class="fas fa-check"></i>
-                    </span>
-                    <span>Submit</span>
-                </button>
-            </div>
         </div>
     </form>
 {% endblock %}
@@ -124,4 +181,6 @@ document.body.addEventListener('htmx:afterSwap', function(event) {
     }
 });
     </script>
+    {# Usability behaviour — section nav active-state #}
+    <script src="{% static 'site/js/issue-form-usability.js' %}"></script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/issue_list.html
+++ b/comicsdb/templates/comicsdb/issue_list.html
@@ -15,6 +15,11 @@
     <section class="section">
         <div class="container">{% include "comicsdb/partials/issue_filter.html" %}</div>
     </section>
+    {% if active_filters %}
+        <section class="section pt-0 pb-0">
+            <div class="container">{% include "comicsdb/partials/active_filters.html" %}</div>
+        </section>
+    {% endif %}
     {% if issue_list %}
         <section class="section pt-0">
             <div class="container">
@@ -31,8 +36,11 @@
                             </p>
                         </div>
                     </div>
-                    {% if user.is_authenticated %}
-                        <div class="level-right">
+                    <div class="level-right">
+                        <div class="level-item">
+                            {% include "comicsdb/partials/issue_sort.html" %}
+                        </div>
+                        {% if user.is_authenticated %}
                             <div class="level-item">
                                 <a class="button is-primary"
                                    href="{% url 'issue:create' %}"
@@ -44,8 +52,8 @@
                                     <span>New</span>
                                 </a>
                             </div>
-                        </div>
-                    {% endif %}
+                        {% endif %}
+                    </div>
                 </nav>
                 {# Issue Cards #}
                 {% include "comicsdb/partials/issue_card_grid.html" with items=issue_list %}

--- a/comicsdb/templates/comicsdb/partials/active_filters.html
+++ b/comicsdb/templates/comicsdb/partials/active_filters.html
@@ -1,0 +1,30 @@
+{% comment %}
+   Tier 2 — active-filter chip bar.
+   Renders only when `active_filters` is non-empty (the including template guards
+   with `{% if active_filters %}`). Each chip is `{label, value, remove_url}`
+   built by views.issue_list_helpers.build_active_filters: `remove_url` is a
+   query string (e.g. "?series_name=Bat") that drops just that one param and
+   resets paging while preserving the rest + current sort. "Clear all" points at
+   `request.path`, wiping every filter in place on whichever list page is active.
+{% endcomment %}
+<div class="field is-grouped is-grouped-multiline is-align-items-center mb-0">
+    <div class="control">
+        <span class="is-size-7 has-text-grey has-text-weight-semibold">Active filters:</span>
+    </div>
+    {% for chip in active_filters %}
+        <div class="control">
+            <div class="tags has-addons mb-0">
+                <span class="tag is-info is-light">
+                    <span class="has-text-weight-semibold mr-1">{{ chip.label }}:</span>{{ chip.value }}
+                </span>
+                <a class="tag is-delete"
+                   href="{{ chip.remove_url }}"
+                   title="Remove {{ chip.label }} filter"
+                   aria-label="Remove {{ chip.label }} filter"></a>
+            </div>
+        </div>
+    {% endfor %}
+    <div class="control">
+        <a class="is-size-7" href="{{ request.path }}">Clear all</a>
+    </div>
+</div>

--- a/comicsdb/templates/comicsdb/partials/active_filters.html
+++ b/comicsdb/templates/comicsdb/partials/active_filters.html
@@ -1,5 +1,5 @@
 {% comment %}
-   Tier 2 — active-filter chip bar.
+   active-filter chip bar.
    Renders only when `active_filters` is non-empty (the including template guards
    with `{% if active_filters %}`). Each chip is `{label, value, remove_url}`
    built by views.issue_list_helpers.build_active_filters: `remove_url` is a

--- a/comicsdb/templates/comicsdb/partials/card_grid.html
+++ b/comicsdb/templates/comicsdb/partials/card_grid.html
@@ -66,12 +66,12 @@
                             {% with count=item.series_count %}
                                 {% if count and count_url_name %}
                                     <a href="{% url count_url_name item.slug %}"
-                                       class="card-footer-item"
+                                       class="card-footer-item is-size-7 has-text-weight-semibold"
                                        aria-label="{{ count }} {{ count_label }} for {{ item }}">
                                         {{ count|intcomma }} {{ count_label }}
                                     </a>
                                 {% else %}
-                                    <span class="card-footer-item" aria-label="No {{ count_label|lower }}s">0 {{ count_label }}s</span>
+                                    <span class="card-footer-item is-size-7" aria-label="No {{ count_label|lower }}s">0 {{ count_label }}s</span>
                                 {% endif %}
                             {% endwith %}
                         {% else %}
@@ -79,19 +79,16 @@
                             {% with count=item.issue_count %}
                                 {% if count and count_url_name %}
                                     <a href="{% url count_url_name item.slug %}"
-                                       class="card-footer-item"
+                                       class="card-footer-item is-size-7 has-text-weight-semibold"
                                        aria-label="{{ count }} {{ count_label }}{{ count|pluralize }} for {{ item }}">
                                         {{ count|intcomma }} {{ count_label }}{{ count|pluralize }}
                                     </a>
                                 {% else %}
-                                    <span class="card-footer-item" aria-label="No {{ count_label|lower }}s">0 {{ count_label }}s</span>
+                                    <span class="card-footer-item is-size-7" aria-label="No {{ count_label|lower }}s">0 {{ count_label }}s</span>
                                 {% endif %}
                             {% endwith %}
                         {% endif %}
                     {% endif %}
-                    <a href="{% url detail_url_name item.slug %}"
-                       class="card-footer-item"
-                       aria-label="View information for {{ item }}">Info</a>
                 </footer>
             </article>
         </div>

--- a/comicsdb/templates/comicsdb/partials/credits_formset.html
+++ b/comicsdb/templates/comicsdb/partials/credits_formset.html
@@ -14,11 +14,7 @@
     <thead>
         <tr>
             <th scope="col">Creator</th>
-            <th scope="col">
-                <span title="Hold down 'Control', or 'Command' on a Mac, to select more than one.">
-                    Role <i class="fas fa-question-circle" aria-hidden="true"></i>
-                </span>
-            </th>
+            <th scope="col">Role</th>
             <th scope="col" class="has-text-centered" style="width: 80px;">Delete</th>
         </tr>
     </thead>

--- a/comicsdb/templates/comicsdb/partials/issue_card_grid.html
+++ b/comicsdb/templates/comicsdb/partials/issue_card_grid.html
@@ -2,8 +2,13 @@
 {% load static %}
 {% load is_new %}
 {% comment %}
-    Issue-specific card grid with "New!" tags and cover date
+    Issue-specific card grid with "New!" tags, publisher, and cover date.
     Usage: {% include "comicsdb/partials/issue_card_grid.html" with items=issue_list %}
+
+    USABILITY CHANGE: the footer now shows the PUBLISHER + COVER DATE
+    instead of a redundant "Info" link. The whole cover already links to the
+    detail page, so the extra link added clicks-to-nowhere; the publisher is
+    far more useful context when scanning a grid of issues.
 {% endcomment %}
 <div class="columns is-multiline">
     {% for issue in items %}
@@ -45,16 +50,18 @@
                         </figure>
                     {% endif %}
                 </div>
-                {# Card Footer #}
+                {# Card Footer — publisher + cover date #}
                 <footer class="card-footer">
-                    <span class="card-footer-item">
+                    <span class="card-footer-item is-size-7"
+                          title="{{ issue.series.publisher }}"
+                          style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; text-align: center;">
+                        {{ issue.series.publisher }}
+                    </span>
+                    <span class="card-footer-item is-size-7 has-text-weight-semibold">
                         <time datetime="{{ issue.cover_date|date:'Y-m' }}">
                             {{ issue.cover_date|date:"M Y" }}
                         </time>
                     </span>
-                    <a href="{% url 'issue:detail' issue.slug %}"
-                       class="card-footer-item"
-                       aria-label="View information for {{ issue }}">Info</a>
                 </footer>
             </article>
         </div>

--- a/comicsdb/templates/comicsdb/partials/issue_filter.html
+++ b/comicsdb/templates/comicsdb/partials/issue_filter.html
@@ -1,4 +1,10 @@
 {% load range_tags %}
+{% comment %}
+    USABILITY CHANGE: the ~14 advanced filter fields are now organised
+    under labelled sub-sections (Series / Issue Numbers / Dates / Codes & IDs)
+    instead of a flat list separated by bare <hr> rules. Same fields, same
+    names, same values — purely a presentation regroup, no view changes needed.
+{% endcomment %}
 <div class="box mb-5" id="filter-panel">
     <form method="get" accept-charset="utf-8">
         <div class="is-flex is-justify-content-space-between is-align-items-center mb-4">
@@ -46,6 +52,9 @@
                     <span>Advanced Filters</span>
                 </span>
             </summary>
+
+            {# ── Group: Series ───────────────────────────────────────────── #}
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">Series</h4>
             <div class="columns is-multiline">
                 {# Series Name Filter #}
                 <div class="column is-half">
@@ -125,7 +134,11 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
+            </div>
+
+            {# ── Group: Issue Numbers ────────────────────────────────────── #}
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">Issue Numbers</h4>
+            <div class="columns is-multiline">
                 {# Issue Number Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -162,7 +175,11 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
+            </div>
+
+            {# ── Group: Dates ────────────────────────────────────────────── #}
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">Dates</h4>
+            <div class="columns is-multiline">
                 {# Cover Year Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -234,7 +251,6 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
                 {# Store Date From Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -303,7 +319,11 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
+            </div>
+
+            {# ── Group: Codes & IDs ──────────────────────────────────────── #}
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">Codes &amp; IDs</h4>
+            <div class="columns is-multiline">
                 {# UPC Code Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -340,7 +360,6 @@
                         </div>
                     </div>
                 </div>
-                <hr class="my-4 column is-full">
                 {# Comic Vine ID Filter #}
                 <div class="column is-half">
                     <div class="field">
@@ -429,6 +448,14 @@ details[open] > summary::before {
 
 details > summary:hover {
     color: hsl(217, 71%, 53%);
+}
+
+/* Group sub-headings inside the advanced panel */
+#filter-panel details h4.title {
+    border-bottom: 1px solid hsl(0, 0%, 93%);
+    padding-bottom: 0.4rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 }
 
 /* Mobile filter buttons styling */

--- a/comicsdb/templates/comicsdb/partials/issue_filter.html
+++ b/comicsdb/templates/comicsdb/partials/issue_filter.html
@@ -43,7 +43,7 @@
             <p class="help">Search series names (supports multi-word search)</p>
         </div>
         {# Collapsible Advanced Filters #}
-        <details {% if has_active_filters %}open{% endif %}>
+        <details>
             <summary class="has-text-weight-semibold is-clickable mt-4 mb-3">
                 <span class="icon-text">
                     <span class="icon">

--- a/comicsdb/templates/comicsdb/partials/issue_sort.html
+++ b/comicsdb/templates/comicsdb/partials/issue_sort.html
@@ -1,0 +1,38 @@
+{% comment %}
+   Tier 2 — result sort control.
+   Submits on change (method="get", no action -> posts back to the current page).
+   Hidden inputs replay every active filter EXCEPT `sort` (replaced here) and
+   `page` (reset to 1 on re-sort). Context: `sort_options` (dict key->{label}),
+   `current_sort` (selected key). Progressive enhancement: a <noscript> submit
+   button keeps it usable without JS.
+{% endcomment %}
+<form method="get"
+      class="field is-grouped is-align-items-center mb-0"
+      aria-label="Sort issues">
+    {% for key, values in request.GET.lists %}
+        {% if key != "sort" and key != "page" %}
+            {% for value in values %}
+                <input type="hidden" name="{{ key }}" value="{{ value }}">
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    <label class="label mb-0 mr-2" for="issue-sort-select">Sort</label>
+    <div class="control">
+        <div class="select">
+            <select id="issue-sort-select"
+                    name="sort"
+                    onchange="this.form.submit()"
+                    aria-label="Sort order">
+                {% for key, opt in sort_options.items %}
+                    <option value="{{ key }}"
+                            {% if key == current_sort %}selected{% endif %}>{{ opt.label }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    </div>
+    <noscript>
+        <div class="control">
+            <button type="submit" class="button">Sort</button>
+        </div>
+    </noscript>
+</form>

--- a/comicsdb/templates/comicsdb/partials/issue_sort.html
+++ b/comicsdb/templates/comicsdb/partials/issue_sort.html
@@ -1,5 +1,5 @@
 {% comment %}
-   Tier 2 — result sort control.
+   result sort control.
    Submits on change (method="get", no action -> posts back to the current page).
    Hidden inputs replay every active filter EXCEPT `sort` (replaced here) and
    `page` (reset to 1 on re-sort). Context: `sort_options` (dict key->{label}),

--- a/comicsdb/templates/comicsdb/partials/series_card_grid.html
+++ b/comicsdb/templates/comicsdb/partials/series_card_grid.html
@@ -39,20 +39,24 @@
                 </div>
                 {# Card Footer #}
                 <footer class="card-footer">
+                    {% if series.publisher %}
+                        <a href="{% url 'publisher:detail' series.publisher.slug %}"
+                           class="card-footer-item is-size-7"
+                           title="{{ series.publisher }}"
+                           style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; text-align: center;"
+                           aria-label="View publisher {{ series.publisher }}">{{ series.publisher }}</a>
+                    {% endif %}
                     {% with count=series.issue_count %}
                         {% if count %}
                             <a href="{% url 'series:issue' series.slug %}"
-                               class="card-footer-item"
+                               class="card-footer-item is-size-7 has-text-weight-semibold"
                                aria-label="{{ count }} issue{{ count|pluralize }} for {{ series }}">
                                 {{ count|intcomma }} issue{{ count|pluralize }}
                             </a>
                         {% else %}
-                            <span class="card-footer-item" aria-label="No issues">0 issues</span>
+                            <span class="card-footer-item is-size-7" aria-label="No issues">0 issues</span>
                         {% endif %}
                     {% endwith %}
-                    <a href="{% url 'series:detail' series.slug %}"
-                       class="card-footer-item"
-                       aria-label="View information for {{ series }}">Info</a>
                 </footer>
             </article>
         </div>

--- a/comicsdb/templates/comicsdb/partials/series_filter.html
+++ b/comicsdb/templates/comicsdb/partials/series_filter.html
@@ -36,7 +36,7 @@
             <p class="help">Search series names (supports multi-word search)</p>
         </div>
         {# Collapsible Advanced Filters #}
-        <details {% if has_active_filters %}open{% endif %}>
+        <details>
             <summary class="has-text-weight-semibold is-clickable mt-4 mb-3">
                 <span class="icon-text">
                     <span class="icon">

--- a/comicsdb/templates/comicsdb/publisher_detail.html
+++ b/comicsdb/templates/comicsdb/publisher_detail.html
@@ -280,27 +280,83 @@
                         </dd>
                     {% endif %}
                 </dl>
-                {# IDs #}
-                <h3 class="title is-6 mt-4">Identification Numbers</h3>
+            </div>
+            {# Identification Numbers #}
+            <div class="box">
+                <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ publisher.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ publisher.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ publisher.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if publisher.cv_id %}
                         <dt class="has-text-weight-bold">Comic Vine:</dt>
-                        <dd class="mb-2">
-                            {{ publisher.cv_id }}
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/publisher/4010-{{ publisher.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ publisher.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ publisher.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if publisher.gcd_id %}
-                        <dt class="has-text-weight-bold">GCD:</dt>
-                        <dd>
-                            {{ publisher.gcd_id }}
+                        <dt class="has-text-weight-bold">
+                            <abbr title="Grand Comics Database">GCD</abbr>:
+                        </dt>
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/publisher/{{ publisher.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ publisher.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ publisher.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
             </div>
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => {
+                            this.innerHTML = originalText;
+                        }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/series_detail.html
+++ b/comicsdb/templates/comicsdb/series_detail.html
@@ -6,9 +6,27 @@
     {{ series.name }}
 {% endblock title %}
 {% block content %}
+    {# Breadcrumb #}
+    <nav class="breadcrumb" aria-label="breadcrumbs">
+        <ul>
+            <li>
+                <a href="{% url 'publisher:detail' series.publisher.slug %}">{{ series.publisher }}</a>
+            </li>
+            <li class="is-active">
+                <a href="#" aria-current="page">{{ series.name }}</a>
+            </li>
+        </ul>
+    </nav>
     {# Page Header #}
     <header class="block">
-        <h1 class="title">{{ series }}</h1>
+        <h1 class="title mb-2">{{ series }}</h1>
+        <p class="subtitle is-5">
+            <a href="{% url 'publisher:detail' series.publisher.slug %}">{{ series.publisher }}</a>
+            {% if series.imprint %}
+                <span class="has-text-grey">&middot;</span>
+                <a href="{% url 'imprint:detail' series.imprint.slug %}">{{ series.imprint }}</a>
+            {% endif %}
+        </p>
     </header>
     {# Navigation Bar #}
     <nav class="level mb-5" aria-label="Series navigation">
@@ -286,28 +304,66 @@
                         </ul>
                     {% endif %}
                 {% endwith %}
-                {# IDs #}
-                <h3 class="title is-6 mt-4">Identification Numbers</h3>
+            </div>
+            {# Identification Numbers #}
+            <div class="box">
+                <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ series.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ series.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ series.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if series.cv_id %}
                         <dt class="has-text-weight-bold">Comic Vine:</dt>
-                        <dd class="mb-2">
-                            {{ series.cv_id }}
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/volume/4050-{{ series.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ series.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ series.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if series.gcd_id %}
-                        <dt class="has-text-weight-bold">GCD:</dt>
-                        <dd>
-                            {{ series.gcd_id }}
+                        <dt class="has-text-weight-bold">
+                            <abbr title="Grand Comics Database">GCD</abbr>:
+                        </dt>
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/series/{{ series.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ series.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ series.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
             </div>
             {# Associated Series #}
+
             {% with assoc=series.associated.all %}
                 {% if assoc %}
                     <div class="box">
@@ -324,4 +380,23 @@
             {% endwith %}
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => {
+                            this.innerHTML = originalText;
+                        }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/series_list.html
+++ b/comicsdb/templates/comicsdb/series_list.html
@@ -14,6 +14,11 @@
     <section class="section">
         <div class="container">{% include "comicsdb/partials/series_filter.html" %}</div>
     </section>
+    {% if active_filters %}
+        <section class="section pt-0 pb-0">
+            <div class="container">{% include "comicsdb/partials/active_filters.html" %}</div>
+        </section>
+    {% endif %}
     {% if series_list %}
         <section class="section pt-0">
             <div class="container">

--- a/comicsdb/templates/comicsdb/team_detail.html
+++ b/comicsdb/templates/comicsdb/team_detail.html
@@ -224,27 +224,81 @@
                         </ul>
                     {% endif %}
                 {% endwith %}
-                {# IDs #}
-                <h3 class="title is-6 mt-4">Identification Numbers</h3>
+            </div>
+            {# Identification Numbers #}
+            <div class="box">
+                <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ team.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ team.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ team.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if team.cv_id %}
                         <dt class="has-text-weight-bold">Comic Vine:</dt>
-                        <dd class="mb-2">
-                            {{ team.cv_id }}
+                        <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://comicvine.gamespot.com/team/4060-{{ team.cv_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ team.cv_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ team.cv_id }}"
+                                    title="Copy Comic Vine ID"
+                                    aria-label="Copy Comic Vine ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                     {% if team.gcd_id %}
-                        <dt class="has-text-weight-bold">GCD:</dt>
-                        <dd>
-                            {{ team.gcd_id }}
+                        <dt class="has-text-weight-bold">
+                            <abbr title="Grand Comics Database">GCD</abbr>:
+                        </dt>
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/group/{{ team.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ team.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ team.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
             </div>
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => { this.innerHTML = originalText; }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/universe_detail.html
+++ b/comicsdb/templates/comicsdb/universe_detail.html
@@ -306,21 +306,62 @@
                         {% endwith %}
                     {% endif %}
                 </dl>
-                {# IDs #}
-                <h3 class="title is-6 mt-4">Identification Numbers</h3>
+            </div>
+            {# Identification Numbers #}
+            <div class="box">
+                <h2 class="title is-6">Identification Numbers</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Metron:</dt>
-                    <dd class="mb-2">
-                        {{ universe.id }}
+                    <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
+                        <span class="is-family-monospace">{{ universe.id }}</span>
+                        <button type="button"
+                                class="button is-small is-light copy-id"
+                                data-copy="{{ universe.id }}"
+                                title="Copy Metron ID"
+                                aria-label="Copy Metron ID">
+                            <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                        </button>
                     </dd>
                     {% if universe.gcd_id %}
-                        <dt class="has-text-weight-bold">GCD:</dt>
-                        <dd>
-                            {{ universe.gcd_id }}
+                        <dt class="has-text-weight-bold">
+                            <abbr title="Grand Comics Database">GCD</abbr>:
+                        </dt>
+                        <dd class="is-flex is-align-items-center is-justify-content-space-between">
+                            <a class="is-family-monospace"
+                               href="https://www.comics.org/universe/{{ universe.gcd_id }}/"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                {{ universe.gcd_id }}
+                                <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                            </a>
+                            <button type="button"
+                                    class="button is-small is-light copy-id"
+                                    data-copy="{{ universe.gcd_id }}"
+                                    title="Copy GCD ID"
+                                    aria-label="Copy GCD ID">
+                                <span class="icon is-small"><i class="fas fa-copy"></i></span>
+                            </button>
                         </dd>
                     {% endif %}
                 </dl>
             </div>
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const copyButtons = document.querySelectorAll('.copy-id');
+            copyButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const id = this.getAttribute('data-copy');
+                    navigator.clipboard.writeText(id).then(() => {
+                        const originalText = this.innerHTML;
+                        this.innerHTML = '<span class="icon is-small"><i class="fas fa-check"></i></span>';
+                        setTimeout(() => { this.innerHTML = originalText; }, 2000);
+                    });
+                });
+            });
+        });
+    </script>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/week_list.html
+++ b/comicsdb/templates/comicsdb/week_list.html
@@ -20,6 +20,11 @@
     <section class="section">
         <div class="container">{% include "comicsdb/partials/issue_filter.html" %}</div>
     </section>
+    {% if active_filters %}
+        <section class="section pt-0 pb-0">
+            <div class="container">{% include "comicsdb/partials/active_filters.html" %}</div>
+        </section>
+    {% endif %}
     {% if issue_list %}
         <section class="section pt-0">
             <div class="container">
@@ -36,8 +41,11 @@
                             </p>
                         </div>
                     </div>
-                    {% if user.is_authenticated %}
-                        <div class="level-right">
+                    <div class="level-right">
+                        <div class="level-item">
+                            {% include "comicsdb/partials/issue_sort.html" %}
+                        </div>
+                        {% if user.is_authenticated %}
                             <div class="level-item">
                                 <a class="button is-primary"
                                    href="{% url 'issue:create' %}"
@@ -49,8 +57,8 @@
                                     <span>New</span>
                                 </a>
                             </div>
-                        </div>
-                    {% endif %}
+                        {% endif %}
+                    </div>
                 </nav>
                 {# Issue Cards #}
                 {% include "comicsdb/partials/issue_card_grid.html" with items=issue_list %}

--- a/comicsdb/views/issue.py
+++ b/comicsdb/views/issue.py
@@ -26,6 +26,11 @@ from comicsdb.models.series import SeriesType
 from comicsdb.models.variant import Variant
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
+from comicsdb.views.issue_list_helpers import (
+    SORT_OPTIONS,
+    apply_sort,
+    build_active_filters,
+)
 from comicsdb.views.mixins import LazyLoadMixin, SlugRedirectView
 from wish_list.models import WishListItem
 
@@ -39,16 +44,23 @@ class IssueList(ListView):
     paginate_by = PAGINATE_BY
 
     def get_queryset(self):
-        queryset = Issue.objects.select_related("series", "series__series_type")
+        queryset = Issue.objects.select_related(
+            "series", "series__series_type", "series__publisher"
+        )
         # Apply filters
         filtered = IssueViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs
+        return apply_sort(filtered.qs, self.request)
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context["series_type"] = SeriesType.objects.values("id", "name").order_by("name")
-        # Check if any filters are active (excluding page parameter)
-        context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_type"] = series_types
+        # Active filters = any GET param that isn't paging or sorting.
+        context["has_active_filters"] = any(key not in ("page", "sort") for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 
@@ -678,10 +690,10 @@ class WeekList(ListView):
 
         queryset = Issue.objects.filter(
             store_date__gte=week_start, store_date__lte=week_end
-        ).select_related("series", "series__series_type")
+        ).select_related("series", "series__series_type", "series__publisher")
         # Apply filters
         filtered = IssueViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs
+        return apply_sort(filtered.qs, self.request)
 
     def get_context_data(self, **kwargs):
         year, week = self.get_week_info()
@@ -690,9 +702,14 @@ class WeekList(ListView):
         context = super().get_context_data(**kwargs)
         context["release_day"] = release_day
         context["future"] = False
-        context["series_type"] = SeriesType.objects.values("id", "name").order_by("name")
-        # Check if any filters are active (excluding page parameter)
-        context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_type"] = series_types
+        # Active filters = any GET param that isn't paging or sorting.
+        context["has_active_filters"] = any(key not in ("page", "sort") for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 
@@ -721,10 +738,10 @@ class NextWeekList(ListView):
 
         queryset = Issue.objects.filter(
             store_date__gte=week_start, store_date__lte=week_end
-        ).select_related("series", "series__series_type")
+        ).select_related("series", "series__series_type", "series__publisher")
         # Apply filters
         filtered = IssueViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs
+        return apply_sort(filtered.qs, self.request)
 
     def get_context_data(self, **kwargs):
         year, week = self.get_week_info()
@@ -733,9 +750,14 @@ class NextWeekList(ListView):
         context = super().get_context_data(**kwargs)
         context["release_day"] = release_day
         context["future"] = False
-        context["series_type"] = SeriesType.objects.values("id", "name").order_by("name")
-        # Check if any filters are active (excluding page parameter)
-        context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_type"] = series_types
+        # Active filters = any GET param that isn't paging or sorting.
+        context["has_active_filters"] = any(key not in ("page", "sort") for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 
@@ -763,11 +785,11 @@ class FutureList(ListView):
 
         # Show all issues after next week
         queryset = Issue.objects.filter(store_date__gt=week_end).select_related(
-            "series", "series__series_type"
+            "series", "series__series_type", "series__publisher"
         )
         # Apply filters
         filtered = IssueViewFilter(self.request.GET, queryset=queryset)
-        return filtered.qs
+        return apply_sort(filtered.qs, self.request)
 
     def get_context_data(self, **kwargs):
         year, week = self.get_week_info()
@@ -776,9 +798,14 @@ class FutureList(ListView):
         context = super().get_context_data(**kwargs)
         context["release_day"] = release_day
         context["future"] = True
-        context["series_type"] = SeriesType.objects.values("id", "name").order_by("name")
-        # Check if any filters are active (excluding page parameter)
-        context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_type"] = series_types
+        # Active filters = any GET param that isn't paging or sorting.
+        context["has_active_filters"] = any(key not in ("page", "sort") for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 

--- a/comicsdb/views/issue_list_helpers.py
+++ b/comicsdb/views/issue_list_helpers.py
@@ -1,0 +1,131 @@
+"""Shared helpers for issue list views: result sorting + active-filter chips.
+
+Kept in its own module so the four issue list views
+(IssueList, WeekList, NextWeekList, FutureList) can share one definition and the
+diff to ``views/issue.py`` stays small. No new dependencies.
+"""
+
+from urllib.parse import urlencode
+
+from comicsdb.models.series import SeriesType
+
+# ---------------------------------------------------------------------------
+# Sorting
+# ---------------------------------------------------------------------------
+# Whitelisted sort options. The GET param ``?sort=`` is validated against these
+# keys, so an arbitrary/garbage value can never reach ``order_by`` — it simply
+# falls back to the model default. The empty key "" is the default (model Meta
+# ordering) and renders first / selected when no sort is chosen.
+SORT_OPTIONS = {
+    "": {
+        "label": "Series A\u2013Z",
+        "order": ["series__sort_name", "cover_date", "store_date", "number"],
+    },
+    "cover_new": {
+        "label": "Cover date (newest)",
+        "order": ["-cover_date", "series__sort_name", "number"],
+    },
+    "cover_old": {
+        "label": "Cover date (oldest)",
+        "order": ["cover_date", "series__sort_name", "number"],
+    },
+    "added": {
+        "label": "Recently added",
+        "order": ["-created_on", "series__sort_name", "number"],
+    },
+}
+
+
+def apply_sort(queryset, request):
+    """Return ``queryset`` ordered per a whitelisted ``?sort=`` param.
+
+    Unknown/empty values leave the queryset on its model-default ordering.
+    """
+    option = SORT_OPTIONS.get(request.GET.get("sort", ""))
+    return queryset.order_by(*option["order"]) if option else queryset
+
+
+# ---------------------------------------------------------------------------
+# Active-filter chips
+# ---------------------------------------------------------------------------
+# GET params that are NOT user-facing filters (so they don't render as chips).
+_NON_FILTER_PARAMS = {"page", "sort"}
+
+# Human-readable labels for each filter param the issue browse exposes.
+FILTER_LABELS = {
+    "q": "Search",
+    "series_name": "Series",
+    "series_type": "Type",
+    "series_volume": "Volume",
+    "publisher_name": "Publisher",
+    "number": "Number",
+    "alt_number": "Alt number",
+    "cover_year": "Cover year",
+    "cover_month": "Cover month",
+    "store_date_after": "Store date from",
+    "store_date_before": "Store date to",
+    "foc_date_after": "FOC date from",
+    "foc_date_before": "FOC date to",
+    "upc": "UPC",
+    "sku": "SKU",
+    "cv_id": "Comic Vine ID",
+    "gcd_id": "GCD ID",
+}
+
+_MONTHS = {
+    "1": "January",
+    "2": "February",
+    "3": "March",
+    "4": "April",
+    "5": "May",
+    "6": "June",
+    "7": "July",
+    "8": "August",
+    "9": "September",
+    "10": "October",
+    "11": "November",
+    "12": "December",
+}
+
+
+def build_active_filters(request, type_names=None):
+    """Build a list of ``{label, value, remove_url}`` dicts for the chip bar.
+
+    ``remove_url`` drops that one param (and resets ``page``) while preserving
+    every other active filter and the current sort.
+
+    Pass ``type_names`` (a ``{str(id): name}`` dict) to avoid a second DB hit
+    when the caller has already fetched SeriesType rows for the filter form.
+    """
+    get = request.GET
+    if type_names is None and get.get("series_type"):
+        type_names = {str(t["id"]): t["name"] for t in SeriesType.objects.values("id", "name")}
+    if type_names is None:
+        type_names = {}
+
+    chips = []
+    for key in get:
+        if key in _NON_FILTER_PARAMS:
+            continue
+        value = get.get(key)
+        if not value:
+            continue
+
+        display = value
+        if key == "series_type":
+            display = type_names.get(value, value)
+        elif key == "cover_month":
+            display = _MONTHS.get(value, value)
+
+        # Every current param except the one being removed and the page cursor.
+        kept = [(k, v) for k, v in get.items() if k not in (key, "page")]
+        remove_url = f"?{urlencode(kept)}" if kept else "?"
+
+        chips.append(
+            {
+                "label": FILTER_LABELS.get(key, key.replace("_", " ").title()),
+                "value": display,
+                "remove_url": remove_url,
+            }
+        )
+    return chips

--- a/comicsdb/views/series.py
+++ b/comicsdb/views/series.py
@@ -18,6 +18,7 @@ from comicsdb.views.mixins import (
     AttributionUpdateMixin,
     SlugRedirectView,
 )
+from comicsdb.views.series_list_helpers import build_active_filters
 from pull_list.models import PullListSeries
 
 LOGGER = logging.getLogger(__name__)
@@ -46,11 +47,12 @@ class SeriesList(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        # Add filter options for the template
-        context["series_types"] = SeriesType.objects.values("id", "name").order_by("name")
+        series_types = list(SeriesType.objects.values("id", "name").order_by("name"))
+        context["series_types"] = series_types
         context["status_choices"] = Series.Status.choices
-        # Check if any filters are active (excluding page parameter)
         context["has_active_filters"] = any(key != "page" for key in self.request.GET)
+        type_names = {str(t["id"]): t["name"] for t in series_types}
+        context["active_filters"] = build_active_filters(self.request, type_names=type_names)
         return context
 
 

--- a/comicsdb/views/series_list_helpers.py
+++ b/comicsdb/views/series_list_helpers.py
@@ -1,0 +1,71 @@
+"""Shared helpers for series list views: active-filter chips.
+
+Mirrors the structure of issue_list_helpers but covers the series filter
+params exposed by SeriesViewFilter.
+"""
+
+from urllib.parse import urlencode
+
+from comicsdb.models import Series, SeriesType
+
+_NON_FILTER_PARAMS = {"page"}
+
+FILTER_LABELS = {
+    "q": "Search",
+    "name": "Name",
+    "series_type": "Type",
+    "publisher_name": "Publisher",
+    "publisher_id": "Publisher ID",
+    "imprint_name": "Imprint",
+    "imprint_id": "Imprint ID",
+    "year_began": "Year Began",
+    "year_began_gte": "Year Began (from)",
+    "year_began_lte": "Year Began (to)",
+    "year_end": "Year Ended",
+    "status": "Status",
+    "volume": "Volume",
+}
+
+_STATUS_LABELS = {str(k): v for k, v in Series.Status.choices}
+
+
+def build_active_filters(request, type_names=None):
+    """Build a list of ``{label, value, remove_url}`` dicts for the chip bar.
+
+    ``remove_url`` drops that one param (and resets ``page``) while preserving
+    every other active filter.
+
+    Pass ``type_names`` (a ``{str(id): name}`` dict) to avoid a second DB hit
+    when the caller has already fetched SeriesType rows for the filter form.
+    """
+    get = request.GET
+    if type_names is None and get.get("series_type"):
+        type_names = {str(t["id"]): t["name"] for t in SeriesType.objects.values("id", "name")}
+    if type_names is None:
+        type_names = {}
+
+    chips = []
+    for key in get:
+        if key in _NON_FILTER_PARAMS:
+            continue
+        value = get.get(key)
+        if not value:
+            continue
+
+        display = value
+        if key == "series_type":
+            display = type_names.get(value, value)
+        elif key == "status":
+            display = _STATUS_LABELS.get(value, value)
+
+        kept = [(k, v) for k, v in get.items() if k not in (key, "page")]
+        remove_url = f"?{urlencode(kept)}" if kept else "?"
+
+        chips.append(
+            {
+                "label": FILTER_LABELS.get(key, key.replace("_", " ").title()),
+                "value": display,
+                "remove_url": remove_url,
+            }
+        )
+    return chips

--- a/static/site/css/issue-form-usability.css
+++ b/static/site/css/issue-form-usability.css
@@ -1,0 +1,124 @@
+/* ==========================================================================
+   Issue form usability enhancements
+   Bulma-compatible. No framework changes; layered on top of existing styles.
+   Used by: comicsdb/templates/comicsdb/issue_form.html
+   ========================================================================== */
+
+/* ---- Sticky action bar ---------------------------------------------------- */
+.usab-actionbar {
+    position: sticky;
+    top: var(--bulma-navbar-height, 3.25rem);
+    z-index: 20; /* Below Bulma navbar fixed z-index of 30 */
+    background: var(--bulma-scheme-main);
+    border: 1px solid var(--bulma-border);
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(10, 10, 10, 0.07);
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.25rem;
+}
+
+@media (prefers-color-scheme: dark) {
+    .usab-actionbar {
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    }
+}
+
+.usab-actionbar__top {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.usab-actionbar__title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--bulma-text-strong);
+    margin: 0;
+}
+
+.usab-actionbar__actions {
+    margin-left: auto;
+    display: flex;
+    gap: 0.5rem;
+}
+
+/* ---- Section nav pills ----------------------------------------------------- */
+.usab-nav {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    margin-top: 0.65rem;
+    padding-top: 0.65rem;
+    border-top: 1px solid var(--bulma-border-weak);
+}
+
+.usab-nav a {
+    padding: 0.3rem 0.85rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    border-radius: 999px;
+    color: var(--bulma-text-weak);
+    text-decoration: none;
+    transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.usab-nav a:hover {
+    background: var(--bulma-background);
+    color: var(--bulma-text-strong);
+}
+
+.usab-nav a.is-active {
+    background: var(--bulma-link-soft);
+    color: var(--bulma-link);
+}
+
+/* ---- Sub-group labels inside the Primary section -------------------------- */
+.usab-group {
+    margin-bottom: 1.5rem;
+}
+
+.usab-group:last-child {
+    margin-bottom: 0;
+}
+
+.usab-group-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 700;
+    color: var(--bulma-text-weak);
+    margin: 0 0 0.85rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--bulma-border-weak);
+}
+
+/* The two-column grid uses Bulma .columns; keep field spacing tidy inside it */
+.usab-group .columns {
+    margin-bottom: 0;
+}
+
+.usab-group .column .field {
+    margin-bottom: 0;
+}
+
+/* Smooth scroll for section-nav anchor links */
+html {
+    scroll-behavior: smooth;
+}
+
+/* Sticky bar offset so anchored headings aren't hidden behind it */
+.box[id^="section-"] {
+    scroll-margin-top: 6.5rem;
+}
+
+/* Mobile: stack the action bar so buttons don't crowd the title */
+@media screen and (max-width: 768px) {
+    .usab-actionbar__actions {
+        margin-left: 0;
+        width: 100%;
+    }
+    .usab-actionbar__actions .button {
+        flex: 1;
+    }
+}

--- a/static/site/js/issue-form-usability.js
+++ b/static/site/js/issue-form-usability.js
@@ -1,0 +1,45 @@
+/* ==========================================================================
+   Issue form usability behaviour
+   1. Section-nav pills: active-state tracking via IntersectionObserver.
+      Smooth scroll is handled by CSS (scroll-behavior: smooth on html).
+   Used by: comicsdb/templates/comicsdb/issue_form.html
+   ========================================================================== */
+(function () {
+    'use strict';
+
+    /* ---- Section nav: active pill via IntersectionObserver --------------- */
+    function initSectionNav() {
+        var nav = document.querySelector('.usab-nav');
+        if (!nav) {
+            return;
+        }
+        var links = Array.prototype.slice.call(nav.querySelectorAll('a[href^="#"]'));
+
+        var sections = links
+            .map(function (l) { return document.querySelector(l.getAttribute('href')); })
+            .filter(Boolean);
+
+        if (!('IntersectionObserver' in window) || !sections.length) {
+            return;
+        }
+
+        var io = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                    var id = '#' + entry.target.id;
+                    links.forEach(function (l) {
+                        l.classList.toggle('is-active', l.getAttribute('href') === id);
+                    });
+                }
+            });
+        }, { rootMargin: '-45% 0px -50% 0px', threshold: 0 });
+
+        sections.forEach(function (s) { io.observe(s); });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initSectionNav);
+    } else {
+        initSectionNav();
+    }
+})();

--- a/tests/comicsdb/test_issue_list_helpers.py
+++ b/tests/comicsdb/test_issue_list_helpers.py
@@ -1,0 +1,141 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.test import RequestFactory
+
+from comicsdb.models.series import SeriesType
+from comicsdb.views.issue_list_helpers import (
+    SORT_OPTIONS,
+    apply_sort,
+    build_active_filters,
+)
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+# ---------------------------------------------------------------------------
+# apply_sort
+# ---------------------------------------------------------------------------
+
+
+def test_apply_sort_default_uses_model_ordering(rf):
+    qs = MagicMock()
+    request = rf.get("/")
+    result = apply_sort(qs, request)
+    qs.order_by.assert_called_once_with(*SORT_OPTIONS[""]["order"])
+    assert result == qs.order_by.return_value
+
+
+def test_apply_sort_cover_new(rf):
+    qs = MagicMock()
+    request = rf.get("/", {"sort": "cover_new"})
+    apply_sort(qs, request)
+    qs.order_by.assert_called_once_with(*SORT_OPTIONS["cover_new"]["order"])
+
+
+def test_apply_sort_cover_old(rf):
+    qs = MagicMock()
+    request = rf.get("/", {"sort": "cover_old"})
+    apply_sort(qs, request)
+    qs.order_by.assert_called_once_with(*SORT_OPTIONS["cover_old"]["order"])
+
+
+def test_apply_sort_added(rf):
+    qs = MagicMock()
+    request = rf.get("/", {"sort": "added"})
+    apply_sort(qs, request)
+    qs.order_by.assert_called_once_with(*SORT_OPTIONS["added"]["order"])
+
+
+def test_apply_sort_unknown_value_returns_queryset_unchanged(rf):
+    qs = MagicMock()
+    request = rf.get("/", {"sort": "garbage_value"})
+    result = apply_sort(qs, request)
+    qs.order_by.assert_not_called()
+    assert result is qs
+
+
+# ---------------------------------------------------------------------------
+# build_active_filters — no DB required
+# ---------------------------------------------------------------------------
+
+
+def test_build_active_filters_empty_returns_no_chips(rf):
+    request = rf.get("/")
+    assert build_active_filters(request) == []
+
+
+def test_build_active_filters_page_and_sort_are_excluded(rf):
+    request = rf.get("/", {"page": "2", "sort": "cover_new"})
+    assert build_active_filters(request) == []
+
+
+def test_build_active_filters_search_chip(rf):
+    request = rf.get("/", {"q": "batman"})
+    chips = build_active_filters(request)
+    assert len(chips) == 1
+    assert chips[0]["label"] == "Search"
+    assert chips[0]["value"] == "batman"
+    assert chips[0]["remove_url"] == "?"
+
+
+def test_build_active_filters_remove_url_preserves_other_params(rf):
+    request = rf.get("/", {"q": "batman", "cover_year": "2020"})
+    chips = build_active_filters(request)
+    assert len(chips) == 2
+    search_chip = next(c for c in chips if c["label"] == "Search")
+    assert "cover_year=2020" in search_chip["remove_url"]
+    assert "q=" not in search_chip["remove_url"]
+
+
+def test_build_active_filters_page_dropped_from_remove_url(rf):
+    request = rf.get("/", {"q": "batman", "page": "3"})
+    chips = build_active_filters(request)
+    assert len(chips) == 1
+    assert "page" not in chips[0]["remove_url"]
+
+
+def test_build_active_filters_cover_month_resolved_to_name(rf):
+    request = rf.get("/", {"cover_month": "4"})
+    chips = build_active_filters(request)
+    assert chips[0]["value"] == "April"
+
+
+def test_build_active_filters_cover_month_unknown_falls_back_to_raw(rf):
+    request = rf.get("/", {"cover_month": "99"})
+    chips = build_active_filters(request)
+    assert chips[0]["value"] == "99"
+
+
+def test_build_active_filters_series_type_resolved_from_supplied_dict(rf):
+    request = rf.get("/", {"series_type": "3"})
+    type_names = {"3": "Ongoing Series"}
+    chips = build_active_filters(request, type_names=type_names)
+    assert chips[0]["label"] == "Type"
+    assert chips[0]["value"] == "Ongoing Series"
+
+
+def test_build_active_filters_series_type_falls_back_to_id_when_not_in_dict(rf):
+    request = rf.get("/", {"series_type": "99"})
+    type_names = {"3": "Ongoing Series"}
+    chips = build_active_filters(request, type_names=type_names)
+    assert chips[0]["value"] == "99"
+
+
+def test_build_active_filters_unknown_param_uses_title_case_label(rf):
+    request = rf.get("/", {"some_custom_param": "foo"})
+    chips = build_active_filters(request)
+    assert chips[0]["label"] == "Some Custom Param"
+
+
+@pytest.mark.django_db
+def test_build_active_filters_fetches_series_type_from_db_when_not_supplied(rf):
+    st = SeriesType.objects.first()
+    if st is None:
+        pytest.skip("No SeriesType rows in DB")
+    request = rf.get("/", {"series_type": str(st.id)})
+    chips = build_active_filters(request)
+    assert chips[0]["value"] == st.name

--- a/tests/comicsdb/test_issue_views.py
+++ b/tests/comicsdb/test_issue_views.py
@@ -1252,8 +1252,8 @@ def test_credits_add_row_returns_form_html(auto_login_user):
     assert b"credits-2" in resp.content
     # Should contain creator field (uses autocomplete widget)
     assert b"credits-2-creator" in resp.content
-    # Should contain role field
-    assert b"id_credits-2-role" in resp.content
+    # Should contain role field (uses autocomplete widget)
+    assert b"credits-2-role__textinput" in resp.content
 
 
 def test_credits_add_row_uses_correct_index(auto_login_user):
@@ -1265,14 +1265,14 @@ def test_credits_add_row_uses_correct_index(auto_login_user):
     assert resp.status_code == HTML_OK_CODE
     assert b"credits-0" in resp.content
     assert b"credits-0-creator" in resp.content
-    assert b"id_credits-0-role" in resp.content
+    assert b"credits-0-role__textinput" in resp.content
 
     # Test with index 5
     resp = client.get(reverse("issue:credits-add-row"), {"form_idx": "5"})
     assert resp.status_code == HTML_OK_CODE
     assert b"credits-5" in resp.content
     assert b"credits-5-creator" in resp.content
-    assert b"id_credits-5-role" in resp.content
+    assert b"credits-5-role__textinput" in resp.content
 
 
 def test_credits_add_row_sequential_indices(auto_login_user):


### PR DESCRIPTION
## Summary

- Add sort controls (Series A–Z, cover date, recently added) to issue list and week list views, with the sort key preserved alongside active filters
- Add active-filter chips below the filter panel that each show a "remove" link to clear one filter at a time, without losing other active filters
- Add breadcrumb navigation and a subtitle line (series link, cover date, content rating tag) to the issue detail page header
- Make Metron, Comic Vine, and GCD IDs copy-to-clipboard with one click; link CV and GCD IDs directly to their external pages
- Extract shared sort/filter-chip logic into `comicsdb/views/issue_list_helpers.py` with full test coverage