### PR TITLE
Improve reading list UI with new card design and detail page stats

### DIFF
--- a/reading_lists/templates/reading_lists/partials/reading_list_rating.html
+++ b/reading_lists/templates/reading_lists/partials/reading_list_rating.html
@@ -1,5 +1,6 @@
 <div id="reading-list-rating-{{ reading_list.pk }}"
-     class="reading-list-rating">
+     class="reading-list-rating"
+     style="scroll-margin-top: 4rem;">
     {% if not reading_list.is_private %}
         {# Display average rating #}
         <div class="average-rating mb-2">

--- a/reading_lists/templates/reading_lists/partials/readinglist_card.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_card.html
@@ -1,0 +1,68 @@
+{% load thumbnail %}
+<div class="column is-one-third-desktop is-half-tablet">
+    <a class="rlc" href="{% url 'reading-list:detail' reading_list.slug %}" data-type="{{ reading_list.list_type }}">
+        <div class="rlc__band">
+            {% thumbnail reading_list.image "640x320" crop="center" format="WEBP" as im %}
+                <span class="rlc__img" style="background-image: url('{{ im.url }}');"></span>
+                <span class="rlc__scrim"></span>
+            {% empty %}
+                <span class="rlc__watermark"><i class="fas fa-layer-group"></i></span>
+            {% endthumbnail %}
+            {% if reading_list.is_private %}
+                <span class="rlc__private">
+                    <span class="icon is-small"><i class="fas fa-lock"></i></span>
+                    <span>Private</span>
+                </span>
+            {% endif %}
+            {% if reading_list.average_rating %}
+                <span class="rlc__rating">
+                    <span class="icon is-small"><i class="fas fa-star"></i></span>
+                    <span>{{ reading_list.average_rating|floatformat:1 }}</span>
+                </span>
+            {% endif %}
+            <span class="rlc__issues">
+                <span class="icon is-small"><i class="fas fa-book"></i></span>
+                <span>{{ reading_list.issue_count }} issue{{ reading_list.issue_count|pluralize }}</span>
+            </span>
+        </div>
+        <div class="rlc__body">
+            <div class="rlc__top">
+                <span class="rlc__type-tag">
+                    <span class="rlc__dot"></span>{{ reading_list.get_list_type_display }}
+                </span>
+                {% if reading_list.start_year_annotated %}
+                    <span class="rlc__span">
+                        <span class="icon is-small"><i class="far fa-calendar"></i></span>
+                        <span>{{ reading_list.start_year_annotated }}{% if reading_list.end_year_annotated and reading_list.end_year_annotated != reading_list.start_year_annotated %}&ndash;{{ reading_list.end_year_annotated }}{% endif %}</span>
+                    </span>
+                {% endif %}
+            </div>
+            <h3 class="rlc__title">{{ reading_list.name }}</h3>
+            {% if reading_list.attribution_source %}
+                <span class="rlc__attr">
+                    <span class="icon is-small"><i class="fas fa-link"></i></span>
+                    <span>{{ reading_list.get_attribution_source_display }}</span>
+                </span>
+            {% endif %}
+            <div class="rlc__meta">
+                <span class="rlc__by">By <strong>{{ reading_list.user.username }}</strong></span>
+                {% if reading_list.average_rating %}
+                    <span class="rlc__stars">
+                        {% for star_num in "12345" %}
+                            <i class="{% if star_num|add:'0' <= reading_list.average_rating %}fas{% else %}far{% endif %} fa-star"></i>
+                        {% endfor %}
+                        <span class="rlc__count">({{ reading_list.rating_count }})</span>
+                    </span>
+                {% endif %}
+            </div>
+            <div class="rlc__foot">
+                {% if reading_list.desc %}
+                    <p class="rlc__desc">{{ reading_list.desc|truncatewords:18 }}</p>
+                {% else %}
+                    <p class="rlc__desc rlc__desc--empty">No description</p>
+                {% endif %}
+                <span class="rlc__updated">Updated {{ reading_list.modified|timesince }} ago</span>
+            </div>
+        </div>
+    </a>
+</div>

--- a/reading_lists/templates/reading_lists/partials/readinglist_filter.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_filter.html
@@ -36,7 +36,7 @@
             <p class="help">Search by reading list name</p>
         </div>
         {# Collapsible Advanced Filters #}
-        <details {% if has_active_filters %}open{% endif %}>
+        <details>
             <summary class="has-text-weight-semibold is-clickable mt-4 mb-3">
                 <span class="icon-text">
                     <span class="icon">

--- a/reading_lists/templates/reading_lists/partials/readinglist_item.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_item.html
@@ -1,38 +1,62 @@
-<li id="item-{{ item.pk }}">
-    <div class="level">
-        <div class="level-left">
-            <div class="level-item">
-                <div>
-                    <a href="{% url 'issue:detail' item.issue.slug %}">{{ item.issue }}</a>
-                    <span class="has-text-grey-light">— {{ item.issue.cover_date|date:"M Y" }}</span>
-                    {% if item.issue_type %}
-                        <span class="tag is-info is-light ml-2">{{ item.get_issue_type_display }}</span>
-                    {% endif %}
-                </div>
-            </div>
+{% load static thumbnail %}
+<li id="item-{{ item.pk }}"
+    class="rl-item"
+    data-issue-type="{{ item.issue_type|default:'UNCATEGORIZED' }}">
+    <div style="display: flex; align-items: center; gap: 1rem; padding: 0.7rem 0.25rem; border-bottom: 1px solid #ededed;">
+        {# Reading-order position #}
+        <span style="width: 2rem; flex: none; text-align: center; font-weight: 700; color: #7a7a7a; font-variant-numeric: tabular-nums;">{{ item.order }}</span>
+
+        {# Cover thumbnail #}
+        <a href="{% url 'issue:detail' item.issue.slug %}" style="flex: none; width: 48px; display: block;">
+            {% if item.issue.image %}
+                {% thumbnail item.issue.image "96x144" format="WEBP" as im %}
+                    <img src="{{ im.url }}"
+                         width="48"
+                         alt="{{ item.issue }}"
+                         loading="lazy"
+                         style="display: block; width: 48px; border-radius: 4px; box-shadow: 0 1px 3px rgba(0,0,0,0.2);">
+                {% endthumbnail %}
+            {% else %}
+                <img src="{% static 'site/img/image-not-found.webp' %}"
+                     width="48"
+                     alt="No image for {{ item.issue }}"
+                     loading="lazy"
+                     style="display: block; width: 48px; border-radius: 4px;">
+            {% endif %}
+        </a>
+
+        {# Title + meta #}
+        <div style="flex: 1 1 0; min-width: 0;">
+            <a href="{% url 'issue:detail' item.issue.slug %}" class="has-text-weight-semibold">{{ item.issue }}</a>
+            <p class="is-size-7 has-text-grey mb-0">
+                {{ item.issue.cover_date|date:"M Y" }}
+                {% if item.issue.series.publisher %}
+                    &middot; <a href="{% url 'publisher:detail' item.issue.series.publisher.slug %}" class="has-text-grey">{{ item.issue.series.publisher }}</a>
+                {% endif %}
+            </p>
         </div>
+
+        {# Issue-type badge #}
+        {% if item.issue_type %}
+            <span class="tag is-light {% if item.issue_type == 'CORE' %}is-link{% elif item.issue_type == 'TIE_IN' %}is-warning{% elif item.issue_type == 'PROLOGUE' %}is-info{% elif item.issue_type == 'EPILOGUE' %}is-success{% endif %}"
+                  style="flex: none;">{{ item.get_issue_type_display }}</span>
+        {% endif %}
+
+        {# Owner controls #}
         {% if is_owner %}
-            <div class="level-right">
-                <div class="level-item">
-                    <div class="buttons has-addons">
-                        <button class="button is-small is-info is-outlined"
-                                hx-get="{% url 'reading-list:edit-issue-type' reading_list_slug item.pk %}"
-                                hx-target="#item-{{ item.pk }}"
-                                hx-swap="outerHTML"
-                                title="Edit issue type">
-                            <span class="icon is-small">
-                                <i class="fas fa-tag"></i>
-                            </span>
-                        </button>
-                        <a href="{% url 'reading-list:remove-issue' reading_list_slug item.pk %}"
-                           class="button is-small is-danger is-outlined"
-                           title="Remove from list">
-                            <span class="icon is-small">
-                                <i class="fas fa-times"></i>
-                            </span>
-                        </a>
-                    </div>
-                </div>
+            <div class="buttons has-addons mb-0" style="flex: none;">
+                <button class="button is-small is-info is-outlined"
+                        hx-get="{% url 'reading-list:edit-issue-type' reading_list_slug item.pk %}"
+                        hx-target="#item-{{ item.pk }}"
+                        hx-swap="outerHTML"
+                        title="Edit issue type">
+                    <span class="icon is-small"><i class="fas fa-tag"></i></span>
+                </button>
+                <a href="{% url 'reading-list:remove-issue' reading_list_slug item.pk %}"
+                   class="button is-small is-danger is-outlined"
+                   title="Remove from list">
+                    <span class="icon is-small"><i class="fas fa-times"></i></span>
+                </a>
             </div>
         {% endif %}
     </div>

--- a/reading_lists/templates/reading_lists/partials/readinglist_item_edit.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_item_edit.html
@@ -1,61 +1,75 @@
-<li id="item-{{ item.pk }}">
-    <div class="level">
-        <div class="level-left">
-            <div class="level-item">
-                <div>
-                    <a href="{% url 'issue:detail' item.issue.slug %}">{{ item.issue }}</a>
-                    <span class="has-text-grey-light">— {{ item.issue.cover_date|date:"M Y" }}</span>
+{% load static thumbnail %}
+<li id="item-{{ item.pk }}"
+    class="rl-item"
+    data-issue-type="{{ item.issue_type|default:'UNCATEGORIZED' }}">
+    <div style="display: flex; align-items: center; gap: 1rem; padding: 0.7rem 0.25rem; border-bottom: 1px solid #ededed;">
+        {# Reading-order position #}
+        <span style="width: 2rem; flex: none; text-align: center; font-weight: 700; color: #7a7a7a; font-variant-numeric: tabular-nums;">{{ item.order }}</span>
+
+        {# Cover thumbnail #}
+        <a href="{% url 'issue:detail' item.issue.slug %}" style="flex: none; width: 48px; display: block;">
+            {% if item.issue.image %}
+                {% thumbnail item.issue.image "96x144" format="WEBP" as im %}
+                    <img src="{{ im.url }}"
+                         width="48"
+                         alt="{{ item.issue }}"
+                         loading="lazy"
+                         style="display: block; width: 48px; border-radius: 4px; box-shadow: 0 1px 3px rgba(0,0,0,0.2);">
+                {% endthumbnail %}
+            {% else %}
+                <img src="{% static 'site/img/image-not-found.webp' %}"
+                     width="48"
+                     alt="No image for {{ item.issue }}"
+                     loading="lazy"
+                     style="display: block; width: 48px; border-radius: 4px;">
+            {% endif %}
+        </a>
+
+        {# Title + meta #}
+        <div style="flex: 1 1 0; min-width: 0;">
+            <a href="{% url 'issue:detail' item.issue.slug %}" class="has-text-weight-semibold">{{ item.issue }}</a>
+            <p class="is-size-7 has-text-grey mb-0">
+                {{ item.issue.cover_date|date:"M Y" }}
+                {% if item.issue.series.publisher %}
+                    &middot; <a href="{% url 'publisher:detail' item.issue.series.publisher.slug %}" class="has-text-grey">{{ item.issue.series.publisher }}</a>
+                {% endif %}
+            </p>
+        </div>
+
+        {# Inline tag edit form #}
+        <form hx-post="{% url 'reading-list:update-issue-type' reading_list_slug item.pk %}"
+              hx-target="#item-{{ item.pk }}"
+              hx-swap="outerHTML"
+              style="flex: none;">
+            {% csrf_token %}
+            <div class="field has-addons mb-0">
+                <div class="control">
+                    <div class="select is-small">
+                        <select name="issue_type">
+                            <option value="">-- No Type --</option>
+                            <option value="PROLOGUE" {% if item.issue_type == 'PROLOGUE' %}selected{% endif %}>Prologue</option>
+                            <option value="CORE" {% if item.issue_type == 'CORE' %}selected{% endif %}>Core</option>
+                            <option value="TIE_IN" {% if item.issue_type == 'TIE_IN' %}selected{% endif %}>Tie-In</option>
+                            <option value="EPILOGUE" {% if item.issue_type == 'EPILOGUE' %}selected{% endif %}>Epilogue</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="control">
+                    <button type="submit" class="button is-small is-success" title="Save">
+                        <span class="icon is-small"><i class="fas fa-check"></i></span>
+                    </button>
+                </div>
+                <div class="control">
+                    <button type="button"
+                            class="button is-small"
+                            hx-get="{% url 'reading-list:cancel-edit-issue-type' reading_list_slug item.pk %}"
+                            hx-target="#item-{{ item.pk }}"
+                            hx-swap="outerHTML"
+                            title="Cancel">
+                        <span class="icon is-small"><i class="fas fa-times"></i></span>
+                    </button>
                 </div>
             </div>
-            <div class="level-item">
-                <form hx-post="{% url 'reading-list:update-issue-type' reading_list_slug item.pk %}"
-                      hx-target="#item-{{ item.pk }}"
-                      hx-swap="outerHTML">
-                    {% csrf_token %}
-                    <div class="field has-addons">
-                        <div class="control">
-                            <div class="select is-small">
-                                <select name="issue_type">
-                                    <option value="">-- No Type --</option>
-                                    <option value="PROLOGUE" {% if item.issue_type == 'PROLOGUE' %}selected{% endif %}>Prologue</option>
-                                    <option value="CORE" {% if item.issue_type == 'CORE' %}selected{% endif %}>Core Issue</option>
-                                    <option value="TIE_IN" {% if item.issue_type == 'TIE_IN' %}selected{% endif %}>Tie-In</option>
-                                    <option value="EPILOGUE" {% if item.issue_type == 'EPILOGUE' %}selected{% endif %}>Epilogue</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="control">
-                            <button type="submit" class="button is-small is-success">
-                                <span class="icon is-small">
-                                    <i class="fas fa-check"></i>
-                                </span>
-                            </button>
-                        </div>
-                        <div class="control">
-                            <button type="button"
-                                    class="button is-small"
-                                    hx-get="{% url 'reading-list:cancel-edit-issue-type' reading_list_slug item.pk %}"
-                                    hx-target="#item-{{ item.pk }}"
-                                    hx-swap="outerHTML">
-                                <span class="icon is-small">
-                                    <i class="fas fa-times"></i>
-                                </span>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </div>
-        </div>
-        <div class="level-right">
-            <div class="level-item">
-                <a href="{% url 'reading-list:remove-issue' reading_list_slug item.pk %}"
-                   class="button is-small is-danger is-outlined"
-                   title="Remove from list">
-                    <span class="icon is-small">
-                        <i class="fas fa-times"></i>
-                    </span>
-                </a>
-            </div>
-        </div>
+        </form>
     </div>
 </li>

--- a/reading_lists/templates/reading_lists/readinglist_detail.html
+++ b/reading_lists/templates/reading_lists/readinglist_detail.html
@@ -308,6 +308,42 @@
                     </div>
                 </div>
             {% endif %}
+
+            {% if featured_creators %}
+                <div class="box">
+                    <h2 class="title is-6">Featured Creators</h2>
+                    {% for entry in featured_creators %}
+                        <article class="media{% if not forloop.last %} mb-4{% endif %}">
+                            <figure class="media-left">
+                                <div class="image is-48x48">
+                                    {% if entry.creator.image %}
+                                        {% thumbnail entry.creator.image "48x48" crop="top" format="WEBP" as im %}
+                                            <img class="is-rounded"
+                                                 src="{{ im.url }}"
+                                                 width="{{ im.width }}"
+                                                 height="{{ im.height }}"
+                                                 alt="{{ entry.creator.name }}"
+                                                 loading="lazy">
+                                        {% endthumbnail %}
+                                    {% else %}
+                                        <img class="is-rounded"
+                                             src="{% static 'site/img/creator-not-found.webp' %}"
+                                             alt="{{ entry.creator.name }}"
+                                             loading="lazy">
+                                    {% endif %}
+                                </div>
+                            </figure>
+                            <div class="media-content">
+                                <a href="{% url 'creator:detail' entry.creator.slug %}"
+                                   class="has-text-weight-semibold is-size-7">{{ entry.creator.name }}</a>
+                                {% if entry.roles %}
+                                    <p class="is-size-7 has-text-grey">{{ entry.roles }}</p>
+                                {% endif %}
+                            </div>
+                        </article>
+                    {% endfor %}
+                </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/reading_lists/templates/reading_lists/readinglist_detail.html
+++ b/reading_lists/templates/reading_lists/readinglist_detail.html
@@ -2,65 +2,146 @@
 {% load static thumbnail %}
 {% block title %}{{ reading_list.name }} - Metron{% endblock %}
 {% block content %}
-    {% if reading_list.image %}
-        {% thumbnail reading_list.image "1200x500" crop="center" format="WEBP" as hero_img %}
-            <header class="block mb-5"
-                    style="position: relative; overflow: hidden; border-radius: 6px; min-height: 200px;">
-                <div style="position: absolute;
-                            inset: 0;
+    {# ============================ HERO ============================ #}
+    <header class="block"
+            style="position: relative; overflow: hidden; border-radius: 6px; background: linear-gradient(150deg, #122c52, #234a82);">
+        {% if reading_list.image %}
+            {% thumbnail reading_list.image "1600x520" crop="center" format="WEBP" as hero_img %}
+                <div style="position: absolute; inset: 0;
                             background-image: url('{{ hero_img.url }}');
-                            background-size: cover;
-                            background-position: center;
-                            opacity: 0.8;"></div>
-                <div style="position: relative; padding: 3rem 2rem;">
-                    <h1 class="title">
-                        {{ reading_list.name }}
-                        {% if reading_list.is_private %}<span class="tag is-warning">Private</span>{% endif %}
-                    </h1>
-                    <p class="subtitle is-6">
-                        Created by <strong>{{ reading_list.user.username }}</strong>
-                    </p>
-                </div>
-            </header>
-        {% endthumbnail %}
-    {% else %}
-        <header class="block">
-            <h1 class="title">
-                {{ reading_list.name }}
-                {% if reading_list.is_private %}<span class="tag is-warning">Private</span>{% endif %}
-            </h1>
-            <p class="subtitle is-6">
-                Created by <strong>{{ reading_list.user.username }}</strong>
+                            background-size: cover; background-position: center;
+                            opacity: 0.45;"></div>
+                <div style="position: absolute; inset: 0;
+                            background: linear-gradient(150deg, rgba(18,44,82,0.65), rgba(35,74,130,0.50));"></div>
+            {% endthumbnail %}
+        {% endif %}
+        <div style="position: relative; z-index: 2; padding: 3rem 2rem;">
+            <p style="text-transform: uppercase; letter-spacing: 3px; font-size: 0.75rem; font-weight: 600; color: #fff; opacity: 0.7; margin-bottom: 0.75rem;">
+                <span class="icon is-small"><i class="fas fa-layer-group"></i></span>
+                Reading List &middot; {{ reading_list.get_list_type_display }}
             </p>
-        </header>
-    {% endif %}
+            <h1 class="title is-1 has-text-white"
+                style="font-weight: 800; letter-spacing: -1px; margin-bottom: 0.75rem;">
+                {{ reading_list.name }}
+                {% if reading_list.is_private %}
+                    <span class="tag is-warning is-medium" style="vertical-align: middle;">Private</span>
+                {% endif %}
+            </h1>
+
+            <div class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 1rem;">
+                <span class="has-text-white">
+                    Curated by
+                    <a href="{% url 'user-detail' username=reading_list.user.username %}"
+                       class="has-text-white has-text-weight-bold"
+                       style="border-bottom: 1px solid rgba(255,255,255,0.4);">{{ reading_list.user.username }}</a>
+                </span>
+                {% if not reading_list.is_private %}
+                    <span style="opacity: 0.4; color: #fff;">|</span>
+                    <span class="has-text-white">
+                        {% if average_rating %}
+                            <span style="color: #ffce54;">
+                                {% for star_num in "12345" %}
+                                    <i class="{% if star_num|add:'0' <= average_rating %}fas{% else %}far{% endif %} fa-star"></i>
+                                {% endfor %}
+                            </span>
+                            <span class="ml-1">{{ average_rating|floatformat:1 }} &middot; {{ rating_count }} rating{{ rating_count|pluralize }}</span>
+                        {% else %}
+                            <span style="opacity: 0.8;">No ratings yet</span>
+                        {% endif %}
+                    </span>
+                    <span style="opacity: 0.4; color: #fff;">|</span>
+                    <span class="tag is-success" style="background: rgba(72,199,142,0.22); color: #a8f0cd;">
+                        <span class="icon is-small"><i class="fas fa-globe"></i></span>
+                        <span>Public</span>
+                    </span>
+                {% endif %}
+            </div>
+
+            <div class="buttons mt-4">
+                <button class="button is-light"
+                        onclick="navigator.clipboard.writeText(window.location.href); var l=this.querySelector('.label-text'); var o=l.textContent; l.textContent='Link copied!'; setTimeout(function(){l.textContent=o;}, 1800);">
+                    <span class="icon is-small"><i class="fas fa-share-alt"></i></span>
+                    <span class="label-text">Share</span>
+                </button>
+                {% if not reading_list.is_private %}
+                    <a class="button is-light is-outlined"
+                       href="#reading-list-rating-{{ reading_list.pk }}"
+                       style="color: #fff; border-color: rgba(255,255,255,0.7);">
+                        <span class="icon is-small"><i class="fas fa-star"></i></span>
+                        <span>Rate this list</span>
+                    </a>
+                {% endif %}
+            </div>
+        </div>
+    </header>
+
+    {# ===================== AT-A-GLANCE SUMMARY ===================== #}
+    <div class="box" style="margin-top: -2.5rem; position: relative; z-index: 3;">
+        <div class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 1.5rem;">
+            <div>
+                <p class="heading">Issues</p>
+                <p class="title is-4 mb-0">{{ reading_list_items_count }}</p>
+            </div>
+            <div style="border-left: 1px solid #ededed; padding-left: 1.5rem;">
+                <p class="heading">Reading span</p>
+                <p class="title is-4 mb-0">
+                    {% if start_year %}
+                        {{ start_year }}{% if end_year and end_year != start_year %}&ndash;{{ end_year }}{% endif %}
+                    {% else %}&mdash;{% endif %}
+                </p>
+            </div>
+            <div style="border-left: 1px solid #ededed; padding-left: 1.5rem;">
+                <p class="heading">Publishers</p>
+                <p class="title is-4 mb-0">{% if publisher_breakdown %}{{ publisher_breakdown|length }}{% else %}{{ publishers|length }}{% endif %}</p>
+            </div>
+            <div style="border-left: 1px solid #ededed; padding-left: 1.5rem;">
+                <p class="heading">Series</p>
+                <p class="title is-4 mb-0">{{ series_breakdown|length }}</p>
+            </div>
+            {% if issue_type_breakdown %}
+                <div class="is-flex-grow-1" style="min-width: 240px; border-left: 1px solid #ededed; padding-left: 1.5rem;">
+                    <p class="heading">Composition</p>
+                    <div style="display: flex; height: 10px; border-radius: 5px; overflow: hidden; background: #ededed;">
+                        {% for seg in issue_type_breakdown %}
+                            <div style="width: {% widthratio seg.count reading_list_items_count 100 %}%; background: {{ seg.color }};"></div>
+                        {% endfor %}
+                    </div>
+                    <div class="is-flex is-flex-wrap-wrap mt-2" style="gap: 0.9rem;">
+                        {% for seg in issue_type_breakdown %}
+                            <span class="is-flex is-align-items-center is-size-7" style="gap: 0.4em;">
+                                <span style="width: 9px; height: 9px; border-radius: 50%; background: {{ seg.color }}; display: inline-block;"></span>
+                                {{ seg.label }} <strong class="ml-1">{{ seg.count }}</strong>
+                            </span>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+
+    {# ===================== OWNER ACTION BAR ===================== #}
     {% if is_owner %}
         <nav class="level mb-5">
             <div class="level-left"></div>
             <div class="level-right">
                 <div class="buttons">
-                    <a class="button is-primary"
-                       href="{% url 'reading-list:add-issue' reading_list.slug %}">
+                    <a class="button is-primary" href="{% url 'reading-list:add-issue' reading_list.slug %}">
                         <span class="icon is-small"><i class="fas fa-plus"></i></span>
                         <span>Add Issues</span>
                     </a>
-                    <a class="button is-primary is-light"
-                       href="{% url 'reading-list:add-from-series' reading_list.slug %}">
+                    <a class="button is-primary is-light" href="{% url 'reading-list:add-from-series' reading_list.slug %}">
                         <span class="icon is-small"><i class="fas fa-layer-group"></i></span>
                         <span>Add from Series</span>
                     </a>
-                    <a class="button is-primary is-light"
-                       href="{% url 'reading-list:add-from-arc' reading_list.slug %}">
+                    <a class="button is-primary is-light" href="{% url 'reading-list:add-from-arc' reading_list.slug %}">
                         <span class="icon is-small"><i class="fas fa-book"></i></span>
                         <span>Add from Arc</span>
                     </a>
-                    <a class="button is-info"
-                       href="{% url 'reading-list:update' reading_list.slug %}">
+                    <a class="button is-info" href="{% url 'reading-list:update' reading_list.slug %}">
                         <span class="icon is-small"><i class="fas fa-edit"></i></span>
                         <span>Edit</span>
                     </a>
-                    <a class="button is-danger"
-                       href="{% url 'reading-list:delete' reading_list.slug %}">
+                    <a class="button is-danger" href="{% url 'reading-list:delete' reading_list.slug %}">
                         <span class="icon is-small"><i class="fas fa-trash"></i></span>
                         <span>Delete</span>
                     </a>
@@ -68,24 +149,40 @@
             </div>
         </nav>
     {% endif %}
+
+    {# ========================= COLUMNS ========================= #}
     <div class="columns">
         <div class="column is-three-quarters">
             {% if reading_list.desc %}
                 <div class="box">
-                    <h2 class="title is-5">Description</h2>
+                    <h2 class="title is-5">About this list</h2>
                     <div class="content">{{ reading_list.desc|linebreaksbr }}</div>
                 </div>
             {% endif %}
+
             <div class="box">
                 <h2 class="title is-5">Issues ({{ reading_list_items_count }})</h2>
                 {% if reading_list_items_count > 0 %}
-                    <div class="content">
-                        <ol id="items-container">
-                            {% for item in reading_list_items %}
-                                {% include "reading_lists/partials/readinglist_item.html" with item=item reading_list_slug=reading_list.slug is_owner=is_owner %}
+                    {# ---- Type filter chips ---- #}
+                    {% if issue_type_breakdown %}
+                        <div class="rl-filters mb-4" style="display: flex; flex-wrap: wrap; gap: 0.4rem;">
+                            <button class="button is-small is-rounded is-link rl-filter" data-filter="all">
+                                All <span class="ml-1 has-text-weight-bold">{{ reading_list_items_count }}</span>
+                            </button>
+                            {% for seg in issue_type_breakdown %}
+                                <button class="button is-small is-rounded rl-filter" data-filter="{{ seg.key }}">
+                                    {{ seg.label }} <span class="ml-1 has-text-weight-bold">{{ seg.count }}</span>
+                                </button>
                             {% endfor %}
-                        </ol>
-                    </div>
+                        </div>
+                    {% endif %}
+
+                    <ol id="items-container" style="list-style: none; margin: 0;">
+                        {% for item in reading_list_items %}
+                            {% include "reading_lists/partials/readinglist_item.html" with item=item reading_list_slug=reading_list.slug is_owner=is_owner %}
+                        {% endfor %}
+                    </ol>
+
                     {% if reading_list_items_count > 50 %}
                         <div id="items-load-more-wrapper" class="has-text-centered mt-4">
                             <button class="button is-link"
@@ -104,18 +201,15 @@
                     <p class="has-text-grey">No issues in this list yet.</p>
                     {% if is_owner %}
                         <div class="buttons mt-3">
-                            <a href="{% url 'reading-list:add-issue' reading_list.slug %}"
-                               class="button is-primary">
+                            <a href="{% url 'reading-list:add-issue' reading_list.slug %}" class="button is-primary">
                                 <span class="icon"><i class="fas fa-plus"></i></span>
                                 <span>Add Issues</span>
                             </a>
-                            <a href="{% url 'reading-list:add-from-series' reading_list.slug %}"
-                               class="button is-primary is-light">
+                            <a href="{% url 'reading-list:add-from-series' reading_list.slug %}" class="button is-primary is-light">
                                 <span class="icon"><i class="fas fa-layer-group"></i></span>
                                 <span>Add from Series</span>
                             </a>
-                            <a href="{% url 'reading-list:add-from-arc' reading_list.slug %}"
-                               class="button is-primary is-light">
+                            <a href="{% url 'reading-list:add-from-arc' reading_list.slug %}" class="button is-primary is-light">
                                 <span class="icon"><i class="fas fa-book"></i></span>
                                 <span>Add from Arc</span>
                             </a>
@@ -124,43 +218,18 @@
                 {% endif %}
             </div>
         </div>
+
+        {# ----------------------- SIDEBAR ----------------------- #}
         <div class="column">
             <div class="box">
-                <h2 class="title is-6">List Details</h2>
+                <h2 class="title is-6">List details</h2>
                 <dl>
                     <dt class="has-text-weight-bold">Owner:</dt>
                     <dd class="mb-3">
-                        {{ reading_list.user.username }}
+                        <a href="{% url 'user-detail' username=reading_list.user.username %}">{{ reading_list.user.username }}</a>
                     </dd>
-                    <dt class="has-text-weight-bold">Issues:</dt>
-                    <dd class="mb-3">
-                        {{ reading_list_items_count }}
-                    </dd>
-                    <dt class="has-text-weight-bold">Rating:</dt>
-                    <dd class="mb-3">
-                        {% include "reading_lists/partials/reading_list_rating.html" %}
-                    </dd>
-                    {% if start_year %}
-                        <dt class="has-text-weight-bold">Year Range:</dt>
-                        <dd class="mb-3">
-                            {% if start_year == end_year %}
-                                {{ start_year }}
-                            {% else %}
-                                {{ start_year }} - {{ end_year }}
-                            {% endif %}
-                        </dd>
-                    {% endif %}
-                    {% if publishers %}
-                        <dt class="has-text-weight-bold">Publishers:</dt>
-                        <dd class="mb-3">
-                            {% for publisher in publishers %}
-                                <a href="{% url 'publisher:detail' publisher.slug %}">{{ publisher.name }}</a>
-                                {% if not forloop.last %},{% endif %}
-                            {% endfor %}
-                        </dd>
-                    {% endif %}
                     <dt class="has-text-weight-bold">Type:</dt>
-                    <dd class="mb-3">{{ reading_list.get_list_type_display }}</dd>
+                    <dd class="mb-3"><span class="tag is-link is-light">{{ reading_list.get_list_type_display }}</span></dd>
                     <dt class="has-text-weight-bold">Visibility:</dt>
                     <dd class="mb-3">
                         {% if reading_list.is_private %}
@@ -169,17 +238,19 @@
                             <span class="tag is-success">Public</span>
                         {% endif %}
                     </dd>
+                    {% if start_year %}
+                        <dt class="has-text-weight-bold">Reading span:</dt>
+                        <dd class="mb-3">
+                            {% if start_year == end_year %}{{ start_year }}{% else %}{{ start_year }} &ndash; {{ end_year }}{% endif %}
+                        </dd>
+                    {% endif %}
                     {% if reading_list.attribution_source %}
                         <dt class="has-text-weight-bold">Source:</dt>
                         <dd class="mb-3">
                             {% if reading_list.attribution_url %}
-                                <a href="{{ reading_list.attribution_url }}"
-                                   target="_blank"
-                                   rel="noopener noreferrer">
+                                <a href="{{ reading_list.attribution_url }}" target="_blank" rel="noopener noreferrer">
                                     {{ reading_list.get_attribution_source_display }}
-                                    <span class="icon is-small">
-                                        <i class="fas fa-external-link-alt"></i>
-                                    </span>
+                                    <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
                                 </a>
                             {% else %}
                                 {{ reading_list.get_attribution_source_display }}
@@ -187,15 +258,84 @@
                         </dd>
                     {% endif %}
                     <dt class="has-text-weight-bold">Created:</dt>
-                    <dd class="mb-3">
-                        {{ reading_list.created_on|date:"F d, Y" }}
-                    </dd>
-                    <dt class="has-text-weight-bold">Last Modified:</dt>
-                    <dd>
-                        {{ reading_list.modified|date:"F d, Y" }}
-                    </dd>
+                    <dd class="mb-3">{{ reading_list.created_on|date:"F d, Y" }}</dd>
+                    <dt class="has-text-weight-bold">Last modified:</dt>
+                    <dd class="mb-3">{{ reading_list.modified|date:"F d, Y" }}</dd>
                 </dl>
+                <hr>
+                {% include "reading_lists/partials/reading_list_rating.html" %}
             </div>
+
+            {% if series_breakdown %}
+                <div class="box">
+                    <h2 class="title is-6">Series in this list</h2>
+                    {% for entry in series_breakdown %}
+                        <div class="is-flex is-align-items-center mb-2" style="gap: 0.6rem;">
+                            <a href="{% url 'series:detail' entry.series.slug %}" class="is-flex-grow-1" style="min-width: 0;">
+                                <span class="is-size-7">{{ entry.series.name }}</span>
+                                <div style="height: 4px; border-radius: 2px; background: #ededed; margin-top: 4px; overflow: hidden;">
+                                    <div style="width: {% widthratio entry.count series_breakdown.0.count 100 %}%; height: 100%; background: #3273dc; opacity: 0.55;"></div>
+                                </div>
+                            </a>
+                            <span class="has-text-grey has-text-weight-bold is-size-7">{{ entry.count }}</span>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% endif %}
+
+            {% if publisher_breakdown %}
+                <div class="box">
+                    <h2 class="title is-6">Publishers</h2>
+                    {% for entry in publisher_breakdown %}
+                        <div class="mb-3">
+                            <div class="is-flex is-justify-content-space-between is-align-items-baseline">
+                                <a href="{% url 'publisher:detail' entry.publisher.slug %}" class="has-text-weight-semibold">{{ entry.publisher.name }}</a>
+                                <span class="has-text-grey is-size-7">{{ entry.count }} issue{{ entry.count|pluralize }}</span>
+                            </div>
+                            <div style="height: 6px; border-radius: 3px; background: #ededed; margin-top: 6px; overflow: hidden;">
+                                <div style="width: {% widthratio entry.count reading_list_items_count 100 %}%; height: 100%; background: #3273dc;"></div>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% elif publishers %}
+                <div class="box">
+                    <h2 class="title is-6">Publishers</h2>
+                    <div class="content">
+                        {% for publisher in publishers %}
+                            <a href="{% url 'publisher:detail' publisher.slug %}">{{ publisher.name }}</a>{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
+{% endblock %}
+{% block js %}
+    <script>
+        (function () {
+            var current = 'all';
+
+            function apply() {
+                document.querySelectorAll('.rl-item').forEach(function (li) {
+                    var t = li.getAttribute('data-issue-type');
+                    li.style.display = (current === 'all' || t === current) ? '' : 'none';
+                });
+            }
+
+            document.querySelectorAll('.rl-filter').forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    current = btn.getAttribute('data-filter');
+                    document.querySelectorAll('.rl-filter').forEach(function (b) {
+                        b.classList.remove('is-link');
+                    });
+                    btn.classList.add('is-link');
+                    apply();
+                });
+            });
+
+            // Re-apply the active filter after HTMX appends more rows.
+            document.body.addEventListener('htmx:afterSwap', apply);
+        })();
+    </script>
 {% endblock %}

--- a/reading_lists/templates/reading_lists/readinglist_detail.html
+++ b/reading_lists/templates/reading_lists/readinglist_detail.html
@@ -309,6 +309,40 @@
                 </div>
             {% endif %}
 
+            {% if top_characters %}
+                <div class="box">
+                    <h2 class="title is-6">Top Characters</h2>
+                    {% for character in top_characters %}
+                        <article class="media{% if not forloop.last %} mb-4{% endif %}">
+                            <figure class="media-left">
+                                <div class="image is-48x48">
+                                    {% if character.image %}
+                                        {% thumbnail character.image "48x48" crop="top" format="WEBP" as im %}
+                                            <img class="is-rounded"
+                                                 src="{{ im.url }}"
+                                                 width="{{ im.width }}"
+                                                 height="{{ im.height }}"
+                                                 alt="{{ character.name }}"
+                                                 loading="lazy">
+                                        {% endthumbnail %}
+                                    {% else %}
+                                        <img class="is-rounded"
+                                             src="{% static 'site/img/image-not-found.webp' %}"
+                                             alt="{{ character.name }}"
+                                             loading="lazy">
+                                    {% endif %}
+                                </div>
+                            </figure>
+                            <div class="media-content" style="align-self: center;">
+                                <a href="{% url 'character:detail' character.slug %}"
+                                   class="has-text-weight-semibold is-size-7">{{ character.name }}</a>
+                                <p class="is-size-7 has-text-grey-light">{{ character.appearance_count }} issue{{ character.appearance_count|pluralize }}</p>
+                            </div>
+                        </article>
+                    {% endfor %}
+                </div>
+            {% endif %}
+
             {% if featured_creators %}
                 <div class="box">
                     <h2 class="title is-6">Featured Creators</h2>

--- a/reading_lists/templates/reading_lists/readinglist_list.html
+++ b/reading_lists/templates/reading_lists/readinglist_list.html
@@ -1,22 +1,23 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load static humanize %}
 {% block title %}Reading Lists - Metron{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
         <h1 class="title">Reading Lists</h1>
     </header>
+    {# Filter partial — unchanged; same composition pattern as issue_list.html #}
     <section class="section">
         <div class="container">{% include "reading_lists/partials/readinglist_filter.html" %}</div>
     </section>
     {% if reading_lists %}
         <section class="section pt-0">
             <div class="container">
-                {# Navigation Bar #}
+                {# Navigation Bar — mirrors issue_list.html: count on the left, actions on the right #}
                 <nav class="level" aria-label="Reading list navigation">
                     <div class="level-left">
                         <div class="level-item">
                             <p class="subtitle is-5">
-                                <strong>{{ page_obj.paginator.count }}</strong> reading list{{ page_obj.paginator.count|pluralize }}
+                                <strong>{{ page_obj.paginator.count|intcomma }}</strong> reading list{{ page_obj.paginator.count|pluralize }}
                             </p>
                         </div>
                     </div>
@@ -24,13 +25,11 @@
                         <div class="level-right">
                             <div class="level-item">
                                 <div class="buttons is-flex-direction-column-mobile">
-                                    <a href="{% url 'reading-list:my-lists' %}"
-                                       class="button is-link ">
+                                    <a href="{% url 'reading-list:my-lists' %}" class="button is-link">
                                         <span class="icon"><i class="fas fa-user"></i></span>
                                         <span>My Reading Lists</span>
                                     </a>
-                                    <a href="{% url 'reading-list:create' %}"
-                                       class="button is-primary ">
+                                    <a href="{% url 'reading-list:create' %}" class="button is-primary">
                                         <span class="icon"><i class="fas fa-plus"></i></span>
                                         <span>Create Reading List</span>
                                     </a>
@@ -42,53 +41,7 @@
                 {# Reading List Cards #}
                 <div class="columns is-multiline">
                     {% for reading_list in reading_lists %}
-                        <div class="column is-one-third">
-                            <div class="card">
-                                <header class="card-header">
-                                    <p class="card-header-title">
-                                        <a href="{% url 'reading-list:detail' reading_list.slug %}">
-                                            {{ reading_list.name }}
-                                            {% if reading_list.attribution_source %}({{ reading_list.attribution_source }}){% endif %}
-                                        </a>
-                                        {% if reading_list.is_private %}<span class="tag is-warning ml-2">Private</span>{% endif %}
-                                    </p>
-                                </header>
-                                <div class="card-content">
-                                    <div class="content">
-                                        <p class="mb-2">
-                                            <span class="tag is-info is-light">{{ reading_list.get_list_type_display }}</span>
-                                        </p>
-                                        <p class="is-size-7 has-text-grey">
-                                            By <strong>{{ reading_list.user.username }}</strong>
-                                        </p>
-                                        {% if reading_list.desc %}
-                                            <p>{{ reading_list.desc|truncatewords:20 }}</p>
-                                        {% else %}
-                                            <p class="has-text-grey-light">No description</p>
-                                        {% endif %}
-                                        <p class="is-size-7">
-                                            <span class="icon-text">
-                                                <span class="icon"><i class="fas fa-book"></i></span>
-                                                <span>{{ reading_list.issue_count }} issue{{ reading_list.issue_count|pluralize }}</span>
-                                            </span>
-                                        </p>
-                                        {% if reading_list.average_rating %}
-                                            <p class="is-size-7">
-                                                <span class="icon-text">
-                                                    {% for star_num in "12345" %}
-                                                        <i class="{% if star_num|add:'0' <= reading_list.average_rating %}fas{% else %}far{% endif %} fa-star"
-                                                           style="color: #ffd700;
-                                                                  font-size: 0.9rem"></i>
-                                                    {% endfor %}
-                                                    <span class="ml-1">{{ reading_list.average_rating|floatformat:1 }} ({{ reading_list.rating_count }})</span>
-                                                </span>
-                                            </p>
-                                        {% endif %}
-                                        <p class="is-size-7 has-text-grey">Updated {{ reading_list.modified|timesince }} ago</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        {% include "reading_lists/partials/readinglist_card.html" with reading_list=reading_list %}
                     {% endfor %}
                 </div>
             </div>
@@ -99,8 +52,7 @@
                 {% if has_active_filters %}
                     <p class="title is-4">No results found</p>
                     <p class="subtitle">Try adjusting your search filters</p>
-                    <a href="{% url 'reading-list:list' %}"
-                       class="button is-light is-medium">
+                    <a href="{% url 'reading-list:list' %}" class="button is-light is-medium">
                         <span class="icon"><i class="fas fa-times"></i></span>
                         <span>Clear All Filters</span>
                     </a>
@@ -108,8 +60,7 @@
                     <p class="title is-4">No reading lists found</p>
                     {% if user.is_authenticated %}
                         <p class="subtitle">Create your first reading list!</p>
-                        <a href="{% url 'reading-list:create' %}"
-                           class="button is-primary is-large">
+                        <a href="{% url 'reading-list:create' %}" class="button is-primary is-large">
                             <span class="icon"><i class="fas fa-plus"></i></span>
                             <span>Create Reading List</span>
                         </a>
@@ -120,6 +71,250 @@
             </div>
         </section>
     {% endif %}
+    {# ---- Card styling. One block for the whole grid; colors keyed off list_type. ---- #}
+    <style>
+    .rlc {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        background: #fff;
+        border: 1px solid #ededed;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 .5em 1em -.125em rgba(10, 10, 10, .1);
+        color: inherit;
+        transition: transform .2s ease, box-shadow .2s ease;
+    }
+
+    .rlc:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 24px rgba(0, 0, 0, .12);
+    }
+
+    .rlc__band {
+        position: relative;
+        height: 150px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+        overflow: hidden;
+        background: linear-gradient(135deg, #4a4a4a, #2b2b2b);
+    }
+
+    .rlc[data-type="EVENT"] .rlc__band { background: linear-gradient(135deg, #3273dc, #244e8f); }
+    .rlc[data-type="STORY"] .rlc__band { background: linear-gradient(135deg, #3e8ed0, #2a6a9e); }
+    .rlc[data-type="CHARACTERS"] .rlc__band { background: linear-gradient(135deg, #48c78e, #2f8c63); }
+    .rlc[data-type="TEAMS"] .rlc__band { background: linear-gradient(135deg, #9b6bd6, #6f43a8); }
+    .rlc[data-type="MASTER"] .rlc__band { background: linear-gradient(135deg, #2a4a7f, #122c52); }
+
+    .rlc__img {
+        position: absolute;
+        inset: 0;
+        display: block;
+        background-size: cover;
+        background-position: center;
+    }
+
+    .rlc__scrim {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(180deg, rgba(0, 0, 0, .04) 40%, rgba(0, 0, 0, .3));
+    }
+
+    .rlc__watermark {
+        color: rgba(255, 255, 255, .26);
+        font-size: 2.6rem;
+    }
+
+    .rlc__private {
+        position: absolute;
+        z-index: 2;
+        top: .6rem;
+        left: .6rem;
+        display: inline-flex;
+        align-items: center;
+        gap: .3em;
+        background: #fffaeb;
+        color: #946c00;
+        font-size: .7rem;
+        font-weight: 700;
+        padding: .25em .55em;
+        border-radius: 5px;
+    }
+
+    .rlc__rating {
+        position: absolute;
+        z-index: 2;
+        top: .6rem;
+        right: .6rem;
+        display: inline-flex;
+        align-items: center;
+        gap: .3em;
+        background: rgba(18, 44, 82, .85);
+        color: #fff;
+        font-size: .75rem;
+        font-weight: 700;
+        padding: .25em .55em;
+        border-radius: 9999px;
+    }
+
+    .rlc__rating .fa-star { color: #ffce54; }
+
+    .rlc__issues {
+        position: absolute;
+        z-index: 2;
+        bottom: .6rem;
+        right: .6rem;
+        display: inline-flex;
+        align-items: center;
+        gap: .3em;
+        background: #fff;
+        color: #363636;
+        font-size: .72rem;
+        font-weight: 700;
+        padding: .25em .6em;
+        border-radius: 9999px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, .15);
+    }
+
+    .rlc__issues .fa-book { color: #3273dc; }
+
+    .rlc__body {
+        display: flex;
+        flex-direction: column;
+        gap: .6rem;
+        flex: 1;
+        padding: 1rem 1.1rem 1.1rem;
+    }
+
+    .rlc__top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: .5rem;
+    }
+
+    .rlc__type-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: .45em;
+        font-size: .72rem;
+        font-weight: 600;
+        padding: .28em .7em;
+        border-radius: 5px;
+        background: #f0f0f0;
+        color: #4a4a4a;
+    }
+
+    .rlc__dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        flex: none;
+        background: #b5b5b5;
+    }
+
+    .rlc[data-type="EVENT"] .rlc__type-tag { background: #eef3fc; color: #2160c4; }
+    .rlc[data-type="EVENT"] .rlc__dot { background: #3273dc; }
+    .rlc[data-type="STORY"] .rlc__type-tag { background: #eef6fc; color: #1d72aa; }
+    .rlc[data-type="STORY"] .rlc__dot { background: #3e8ed0; }
+    .rlc[data-type="CHARACTERS"] .rlc__type-tag { background: #effaf5; color: #257953; }
+    .rlc[data-type="CHARACTERS"] .rlc__dot { background: #48c78e; }
+    .rlc[data-type="TEAMS"] .rlc__type-tag { background: #f5eefc; color: #7a3fc0; }
+    .rlc[data-type="TEAMS"] .rlc__dot { background: #9b6bd6; }
+    .rlc[data-type="MASTER"] .rlc__type-tag { background: #eaeef5; color: #122c52; }
+    .rlc[data-type="MASTER"] .rlc__dot { background: #2a4a7f; }
+
+    .rlc__span {
+        display: inline-flex;
+        align-items: center;
+        gap: .4em;
+        font-size: .72rem;
+        color: #7a7a7a;
+        white-space: nowrap;
+    }
+
+    .rlc__title {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 700;
+        line-height: 1.25;
+        color: #1a1a2e;
+    }
+
+    .rlc__attr {
+        align-self: flex-start;
+        display: inline-flex;
+        align-items: center;
+        gap: .35em;
+        font-size: .72rem;
+        color: #7a7a7a;
+        background: #f5f6f7;
+        padding: .25em .6em;
+        border-radius: 5px;
+    }
+
+    .rlc__meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: .5rem;
+        font-size: .8rem;
+        color: #7a7a7a;
+    }
+
+    .rlc__stars .fa-star { font-size: .72rem; color: #f5b400; }
+    .rlc__count { margin-left: .25em; color: #7a7a7a; }
+
+    .rlc__foot {
+        margin-top: auto;
+        padding-top: .55rem;
+        border-top: 1px solid #ededed;
+        display: flex;
+        flex-direction: column;
+        gap: .4rem;
+    }
+
+    .rlc__desc { margin: 0; font-size: .82rem; color: #4a4a4a; }
+    .rlc__desc--empty { color: #b5b5b5; font-style: italic; }
+    .rlc__updated { font-size: .72rem; color: #9a9a9a; }
+
+    @media (prefers-color-scheme: dark) {
+        .rlc {
+            background: #1f2937;
+            border-color: #374151;
+            box-shadow: 0 .5em 1em -.125em rgba(0, 0, 0, .4);
+        }
+        .rlc:hover { box-shadow: 0 8px 24px rgba(0, 0, 0, .4); }
+
+        .rlc__issues { background: #374151; color: #e5e7eb; }
+
+        .rlc__type-tag { background: #374151; color: #d1d5db; }
+        .rlc__dot { background: #6b7280; }
+
+        .rlc[data-type="EVENT"] .rlc__type-tag { background: #1e3a6e; color: #93b4f3; }
+        .rlc[data-type="EVENT"] .rlc__dot { background: #3273dc; }
+        .rlc[data-type="STORY"] .rlc__type-tag { background: #1a3a54; color: #7abfe8; }
+        .rlc[data-type="STORY"] .rlc__dot { background: #3e8ed0; }
+        .rlc[data-type="CHARACTERS"] .rlc__type-tag { background: #1a3d2e; color: #6dd8a8; }
+        .rlc[data-type="CHARACTERS"] .rlc__dot { background: #48c78e; }
+        .rlc[data-type="TEAMS"] .rlc__type-tag { background: #2e1d4e; color: #c49ef5; }
+        .rlc[data-type="TEAMS"] .rlc__dot { background: #9b6bd6; }
+        .rlc[data-type="MASTER"] .rlc__type-tag { background: #0f1e38; color: #8aa4cc; }
+        .rlc[data-type="MASTER"] .rlc__dot { background: #2a4a7f; }
+
+        .rlc__span { color: #9ca3af; }
+        .rlc__title { color: #f3f4f6; }
+        .rlc__attr { background: #374151; color: #9ca3af; }
+        .rlc__meta { color: #9ca3af; }
+        .rlc__count { color: #9ca3af; }
+        .rlc__foot { border-top-color: #374151; }
+        .rlc__desc { color: #d1d5db; }
+        .rlc__desc--empty { color: #6b7280; }
+        .rlc__updated { color: #6b7280; }
+    }
+    </style>
 {% endblock %}
 {% block pagination %}
     {% load pagination_tags %}

--- a/reading_lists/templates/reading_lists/user_readinglist_list.html
+++ b/reading_lists/templates/reading_lists/user_readinglist_list.html
@@ -1,69 +1,115 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load static humanize thumbnail %}
 {% block title %}My Reading Lists - Metron{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
         <h1 class="title">My Reading Lists</h1>
     </header>
-    <div class="block has-text-centered">
-        <div class="buttons is-centered">
-            <a href="{% url 'reading-list:list' %}" class="button">
-                <span class="icon"><i class="fas fa-list"></i></span>
-                <span>All Reading Lists</span>
-            </a>
-            <a href="{% url 'reading-list:create' %}" class="button is-primary">
-                <span class="icon"><i class="fas fa-plus"></i></span>
-                <span>Create New List</span>
-            </a>
-        </div>
-    </div>
     {% if reading_lists %}
-        <section class="section">
+        <section class="section pt-0">
             <div class="container">
+                <nav class="level" aria-label="Reading list navigation">
+                    <div class="level-left">
+                        <div class="level-item">
+                            <p class="subtitle is-5">
+                                <strong>{{ page_obj.paginator.count|intcomma }}</strong> reading list{{ page_obj.paginator.count|pluralize }}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="level-right">
+                        <div class="level-item">
+                            <div class="buttons is-flex-direction-column-mobile">
+                                <a href="{% url 'reading-list:list' %}" class="button is-link">
+                                    <span class="icon"><i class="fas fa-list"></i></span>
+                                    <span>All Reading Lists</span>
+                                </a>
+                                <a href="{% url 'reading-list:create' %}" class="button is-primary">
+                                    <span class="icon"><i class="fas fa-plus"></i></span>
+                                    <span>Create Reading List</span>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </nav>
                 <div class="columns is-multiline">
                     {% for reading_list in reading_lists %}
-                        <div class="column is-one-third">
-                            <div class="card">
-                                <header class="card-header">
-                                    <p class="card-header-title">
-                                        <a href="{% url 'reading-list:detail' reading_list.slug %}">
-                                            {{ reading_list.name }}
-                                            {% if reading_list.attribution_source %}({{ reading_list.attribution_source }}){% endif %}
-                                        </a>
-                                        {% if reading_list.is_private %}<span class="tag is-warning ml-2">Private</span>{% endif %}
-                                    </p>
-                                </header>
-                                <div class="card-content">
-                                    <div class="content">
-                                        <p class="mb-2">
-                                            <span class="tag is-info is-light">{{ reading_list.get_list_type_display }}</span>
-                                        </p>
-                                        {% if reading_list.desc %}
-                                            <p>{{ reading_list.desc|truncatewords:20 }}</p>
-                                        {% else %}
-                                            <p class="has-text-grey-light">No description</p>
-                                        {% endif %}
-                                        <p class="is-size-7">
-                                            <span class="icon-text">
-                                                <span class="icon"><i class="fas fa-book"></i></span>
-                                                <span>{{ reading_list.issue_count }} issue{{ reading_list.issue_count|pluralize }}</span>
+                        <div class="column is-one-third-desktop is-half-tablet">
+                            <div class="rlc-wrap">
+                            <a class="rlc" href="{% url 'reading-list:detail' reading_list.slug %}" data-type="{{ reading_list.list_type }}">
+                                <div class="rlc__band">
+                                    {% thumbnail reading_list.image "640x320" crop="center" format="WEBP" as im %}
+                                        <span class="rlc__img" style="background-image: url('{{ im.url }}');"></span>
+                                        <span class="rlc__scrim"></span>
+                                    {% empty %}
+                                        <span class="rlc__watermark"><i class="fas fa-layer-group"></i></span>
+                                    {% endthumbnail %}
+                                    {% if reading_list.is_private %}
+                                        <span class="rlc__private">
+                                            <span class="icon is-small"><i class="fas fa-lock"></i></span>
+                                            <span>Private</span>
+                                        </span>
+                                    {% endif %}
+                                    {% if reading_list.average_rating %}
+                                        <span class="rlc__rating">
+                                            <span class="icon is-small"><i class="fas fa-star"></i></span>
+                                            <span>{{ reading_list.average_rating|floatformat:1 }}</span>
+                                        </span>
+                                    {% endif %}
+                                    <span class="rlc__issues">
+                                        <span class="icon is-small"><i class="fas fa-book"></i></span>
+                                        <span>{{ reading_list.issue_count }} issue{{ reading_list.issue_count|pluralize }}</span>
+                                    </span>
+                                </div>
+                                <div class="rlc__body">
+                                    <div class="rlc__top">
+                                        <span class="rlc__type-tag">
+                                            <span class="rlc__dot"></span>{{ reading_list.get_list_type_display }}
+                                        </span>
+                                        {% if reading_list.start_year_annotated %}
+                                            <span class="rlc__span">
+                                                <span class="icon is-small"><i class="far fa-calendar"></i></span>
+                                                <span>{{ reading_list.start_year_annotated }}{% if reading_list.end_year_annotated and reading_list.end_year_annotated != reading_list.start_year_annotated %}&ndash;{{ reading_list.end_year_annotated }}{% endif %}</span>
                                             </span>
-                                        </p>
-                                        <p class="is-size-7 has-text-grey">Updated {{ reading_list.modified|timesince }} ago</p>
+                                        {% endif %}
+                                    </div>
+                                    <h3 class="rlc__title">{{ reading_list.name }}</h3>
+                                    {% if reading_list.attribution_source %}
+                                        <span class="rlc__attr">
+                                            <span class="icon is-small"><i class="fas fa-link"></i></span>
+                                            <span>{{ reading_list.get_attribution_source_display }}</span>
+                                        </span>
+                                    {% endif %}
+                                    <div class="rlc__meta">
+                                        <span class="rlc__by">By <strong>{{ reading_list.user.username }}</strong></span>
+                                        {% if reading_list.average_rating %}
+                                            <span class="rlc__stars">
+                                                {% for star_num in "12345" %}
+                                                    <i class="{% if star_num|add:'0' <= reading_list.average_rating %}fas{% else %}far{% endif %} fa-star"></i>
+                                                {% endfor %}
+                                                <span class="rlc__count">({{ reading_list.rating_count }})</span>
+                                            </span>
+                                        {% endif %}
+                                    </div>
+                                    <div class="rlc__foot">
+                                        {% if reading_list.desc %}
+                                            <p class="rlc__desc">{{ reading_list.desc|truncatewords:18 }}</p>
+                                        {% else %}
+                                            <p class="rlc__desc rlc__desc--empty">No description</p>
+                                        {% endif %}
+                                        <span class="rlc__updated">Updated {{ reading_list.modified|timesince }} ago</span>
                                     </div>
                                 </div>
-                                <footer class="card-footer">
-                                    <a href="{% url 'reading-list:update' reading_list.slug %}"
-                                       class="card-footer-item">
-                                        <span class="icon"><i class="fas fa-edit"></i></span>
-                                        <span>Edit</span>
-                                    </a>
-                                    <a href="{% url 'reading-list:delete' reading_list.slug %}"
-                                       class="card-footer-item has-text-danger">
-                                        <span class="icon"><i class="fas fa-trash"></i></span>
-                                        <span>Delete</span>
-                                    </a>
-                                </footer>
+                            </a>
+                            <div class="rlc-actions">
+                                <a href="{% url 'reading-list:update' reading_list.slug %}" class="button is-small is-fullwidth">
+                                    <span class="icon"><i class="fas fa-edit"></i></span>
+                                    <span>Edit</span>
+                                </a>
+                                <a href="{% url 'reading-list:delete' reading_list.slug %}" class="button is-small is-fullwidth has-text-danger">
+                                    <span class="icon"><i class="fas fa-trash"></i></span>
+                                    <span>Delete</span>
+                                </a>
+                            </div>
                             </div>
                         </div>
                     {% endfor %}
@@ -71,18 +117,276 @@
             </div>
         </section>
     {% else %}
-        <section class="section">
+        <section class="section pt-0">
             <div class="container has-text-centered">
                 <p class="title is-4">You don't have any reading lists yet</p>
                 <p class="subtitle">Create your first reading list!</p>
-                <a href="{% url 'reading-list:create' %}"
-                   class="button is-primary is-large">
+                <a href="{% url 'reading-list:create' %}" class="button is-primary is-large">
                     <span class="icon"><i class="fas fa-plus"></i></span>
                     <span>Create Reading List</span>
                 </a>
             </div>
         </section>
     {% endif %}
+    <style>
+    .rlc-wrap {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
+    .rlc-wrap .rlc { flex: 1; }
+
+    .rlc-actions {
+        display: flex;
+        gap: .5rem;
+        padding-top: .5rem;
+    }
+
+    .rlc-actions .button { flex: 1; }
+
+    .rlc {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        background: #fff;
+        border: 1px solid #ededed;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 .5em 1em -.125em rgba(10, 10, 10, .1);
+        color: inherit;
+        transition: transform .2s ease, box-shadow .2s ease;
+    }
+
+    .rlc:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 24px rgba(0, 0, 0, .12);
+    }
+
+    .rlc__band {
+        position: relative;
+        height: 150px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+        overflow: hidden;
+        background: linear-gradient(135deg, #4a4a4a, #2b2b2b);
+    }
+
+    .rlc[data-type="EVENT"] .rlc__band { background: linear-gradient(135deg, #3273dc, #244e8f); }
+    .rlc[data-type="STORY"] .rlc__band { background: linear-gradient(135deg, #3e8ed0, #2a6a9e); }
+    .rlc[data-type="CHARACTERS"] .rlc__band { background: linear-gradient(135deg, #48c78e, #2f8c63); }
+    .rlc[data-type="TEAMS"] .rlc__band { background: linear-gradient(135deg, #9b6bd6, #6f43a8); }
+    .rlc[data-type="MASTER"] .rlc__band { background: linear-gradient(135deg, #2a4a7f, #122c52); }
+
+    .rlc__img {
+        position: absolute;
+        inset: 0;
+        display: block;
+        background-size: cover;
+        background-position: center;
+    }
+
+    .rlc__scrim {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(180deg, rgba(0, 0, 0, .04) 40%, rgba(0, 0, 0, .3));
+    }
+
+    .rlc__watermark {
+        color: rgba(255, 255, 255, .26);
+        font-size: 2.6rem;
+    }
+
+    .rlc__private {
+        position: absolute;
+        z-index: 2;
+        top: .6rem;
+        left: .6rem;
+        display: inline-flex;
+        align-items: center;
+        gap: .3em;
+        background: #fffaeb;
+        color: #946c00;
+        font-size: .7rem;
+        font-weight: 700;
+        padding: .25em .55em;
+        border-radius: 5px;
+    }
+
+    .rlc__rating {
+        position: absolute;
+        z-index: 2;
+        top: .6rem;
+        right: .6rem;
+        display: inline-flex;
+        align-items: center;
+        gap: .3em;
+        background: rgba(18, 44, 82, .85);
+        color: #fff;
+        font-size: .75rem;
+        font-weight: 700;
+        padding: .25em .55em;
+        border-radius: 9999px;
+    }
+
+    .rlc__rating .fa-star { color: #ffce54; }
+
+    .rlc__issues {
+        position: absolute;
+        z-index: 2;
+        bottom: .6rem;
+        right: .6rem;
+        display: inline-flex;
+        align-items: center;
+        gap: .3em;
+        background: #fff;
+        color: #363636;
+        font-size: .72rem;
+        font-weight: 700;
+        padding: .25em .6em;
+        border-radius: 9999px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, .15);
+    }
+
+    .rlc__issues .fa-book { color: #3273dc; }
+
+    .rlc__body {
+        display: flex;
+        flex-direction: column;
+        gap: .6rem;
+        flex: 1;
+        padding: 1rem 1.1rem 1.1rem;
+    }
+
+    .rlc__top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: .5rem;
+    }
+
+    .rlc__type-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: .45em;
+        font-size: .72rem;
+        font-weight: 600;
+        padding: .28em .7em;
+        border-radius: 5px;
+        background: #f0f0f0;
+        color: #4a4a4a;
+    }
+
+    .rlc__dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        flex: none;
+        background: #b5b5b5;
+    }
+
+    .rlc[data-type="EVENT"] .rlc__type-tag { background: #eef3fc; color: #2160c4; }
+    .rlc[data-type="EVENT"] .rlc__dot { background: #3273dc; }
+    .rlc[data-type="STORY"] .rlc__type-tag { background: #eef6fc; color: #1d72aa; }
+    .rlc[data-type="STORY"] .rlc__dot { background: #3e8ed0; }
+    .rlc[data-type="CHARACTERS"] .rlc__type-tag { background: #effaf5; color: #257953; }
+    .rlc[data-type="CHARACTERS"] .rlc__dot { background: #48c78e; }
+    .rlc[data-type="TEAMS"] .rlc__type-tag { background: #f5eefc; color: #7a3fc0; }
+    .rlc[data-type="TEAMS"] .rlc__dot { background: #9b6bd6; }
+    .rlc[data-type="MASTER"] .rlc__type-tag { background: #eaeef5; color: #122c52; }
+    .rlc[data-type="MASTER"] .rlc__dot { background: #2a4a7f; }
+
+    .rlc__span {
+        display: inline-flex;
+        align-items: center;
+        gap: .4em;
+        font-size: .72rem;
+        color: #7a7a7a;
+        white-space: nowrap;
+    }
+
+    .rlc__title {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 700;
+        line-height: 1.25;
+        color: #1a1a2e;
+    }
+
+    .rlc__attr {
+        align-self: flex-start;
+        display: inline-flex;
+        align-items: center;
+        gap: .35em;
+        font-size: .72rem;
+        color: #7a7a7a;
+        background: #f5f6f7;
+        padding: .25em .6em;
+        border-radius: 5px;
+    }
+
+    .rlc__meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: .5rem;
+        font-size: .8rem;
+        color: #7a7a7a;
+    }
+
+    .rlc__stars .fa-star { font-size: .72rem; color: #f5b400; }
+    .rlc__count { margin-left: .25em; color: #7a7a7a; }
+
+    .rlc__foot {
+        margin-top: auto;
+        padding-top: .55rem;
+        border-top: 1px solid #ededed;
+        display: flex;
+        flex-direction: column;
+        gap: .4rem;
+    }
+
+    .rlc__desc { margin: 0; font-size: .82rem; color: #4a4a4a; }
+    .rlc__desc--empty { color: #b5b5b5; font-style: italic; }
+    .rlc__updated { font-size: .72rem; color: #9a9a9a; }
+
+    @media (prefers-color-scheme: dark) {
+        .rlc {
+            background: #1f2937;
+            border-color: #374151;
+            box-shadow: 0 .5em 1em -.125em rgba(0, 0, 0, .4);
+        }
+        .rlc:hover { box-shadow: 0 8px 24px rgba(0, 0, 0, .4); }
+
+        .rlc__issues { background: #374151; color: #e5e7eb; }
+
+        .rlc__type-tag { background: #374151; color: #d1d5db; }
+        .rlc__dot { background: #6b7280; }
+
+        .rlc[data-type="EVENT"] .rlc__type-tag { background: #1e3a6e; color: #93b4f3; }
+        .rlc[data-type="EVENT"] .rlc__dot { background: #3273dc; }
+        .rlc[data-type="STORY"] .rlc__type-tag { background: #1a3a54; color: #7abfe8; }
+        .rlc[data-type="STORY"] .rlc__dot { background: #3e8ed0; }
+        .rlc[data-type="CHARACTERS"] .rlc__type-tag { background: #1a3d2e; color: #6dd8a8; }
+        .rlc[data-type="CHARACTERS"] .rlc__dot { background: #48c78e; }
+        .rlc[data-type="TEAMS"] .rlc__type-tag { background: #2e1d4e; color: #c49ef5; }
+        .rlc[data-type="TEAMS"] .rlc__dot { background: #9b6bd6; }
+        .rlc[data-type="MASTER"] .rlc__type-tag { background: #0f1e38; color: #8aa4cc; }
+        .rlc[data-type="MASTER"] .rlc__dot { background: #2a4a7f; }
+
+        .rlc__span { color: #9ca3af; }
+        .rlc__title { color: #f3f4f6; }
+        .rlc__attr { background: #374151; color: #9ca3af; }
+        .rlc__meta { color: #9ca3af; }
+        .rlc__count { color: #9ca3af; }
+        .rlc__foot { border-top-color: #374151; }
+        .rlc__desc { color: #d1d5db; }
+        .rlc__desc--empty { color: #6b7280; }
+        .rlc__updated { color: #6b7280; }
+    }
+    </style>
 {% endblock %}
 {% block pagination %}
     {% load pagination_tags %}

--- a/reading_lists/views.py
+++ b/reading_lists/views.py
@@ -259,15 +259,53 @@ class ReadingListDetailView(DetailView):
 
         # Prefetch publishers efficiently
         if reading_list_items_count > 0:
-            # Get unique publishers from already-prefetched data
-            publishers = {}
+            # Display label + bar color for each ReadingListItem.IssueType
+            type_meta = {
+                "CORE": ("Core", "#3273dc"),
+                "TIE_IN": ("Tie-In", "#f5b400"),
+                "PROLOGUE": ("Prologue", "#3e8ed0"),
+                "EPILOGUE": ("Epilogue", "#48c78e"),
+            }
+
+            type_counts = {}
+            series_counts = {}
+            publisher_counts = {}
+
             for item in reading_list_items:
-                publisher = item.issue.series.publisher
-                if publisher and publisher.id not in publishers:
-                    publishers[publisher.id] = publisher
-            context["publishers"] = sorted(publishers.values(), key=lambda p: p.name)
-        else:
-            context["publishers"] = []
+                key = item.issue_type or ""
+                if key:
+                    type_counts[key] = type_counts.get(key, 0) + 1
+
+                series = item.issue.series
+                s_entry = series_counts.setdefault(series.id, {"series": series, "count": 0})
+                s_entry["count"] += 1
+
+                publisher = series.publisher
+                if publisher:
+                    p_entry = publisher_counts.setdefault(
+                        publisher.id, {"publisher": publisher, "count": 0}
+                    )
+                    p_entry["count"] += 1
+
+            context["issue_type_breakdown"] = [
+                {
+                    "key": k,
+                    "label": type_meta[k][0],
+                    "color": type_meta[k][1],
+                    "count": type_counts[k],
+                }
+                for k in ("CORE", "TIE_IN", "PROLOGUE", "EPILOGUE")
+                if type_counts.get(k)
+            ]
+
+            context["series_breakdown"] = sorted(
+                series_counts.values(),
+                key=lambda e: (-e["count"], e["series"].name),
+            )
+            context["publisher_breakdown"] = sorted(
+                publisher_counts.values(),
+                key=lambda e: (-e["count"], e["publisher"].name),
+            )
 
         return context
 

--- a/reading_lists/views.py
+++ b/reading_lists/views.py
@@ -64,6 +64,8 @@ class ReadingListListView(ListView):
             issue_count=Count("issues", distinct=True),
             average_rating=Avg("ratings__rating"),
             rating_count=Count("ratings", distinct=True),
+            start_year_annotated=Min("reading_list_items__issue__cover_date__year"),
+            end_year_annotated=Max("reading_list_items__issue__cover_date__year"),
         )
 
         if self.request.user.is_authenticated:
@@ -115,6 +117,8 @@ class SearchReadingListListView(SearchMixin, ReadingListListView):
             issue_count=Count("issues", distinct=True),
             average_rating=Avg("ratings__rating"),
             rating_count=Count("ratings", distinct=True),
+            start_year_annotated=Min("reading_list_items__issue__cover_date__year"),
+            end_year_annotated=Max("reading_list_items__issue__cover_date__year"),
         )
 
         if self.request.user.is_authenticated:
@@ -161,6 +165,8 @@ class UserReadingListListView(LoginRequiredMixin, ListView):
                 issue_count=Count("issues", distinct=True),
                 average_rating=Avg("ratings__rating"),
                 rating_count=Count("ratings", distinct=True),
+                start_year_annotated=Min("reading_list_items__issue__cover_date__year"),
+                end_year_annotated=Max("reading_list_items__issue__cover_date__year"),
             )
             .order_by("name", "attribution_source", "user")
         )

--- a/reading_lists/views.py
+++ b/reading_lists/views.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, DeleteView, DetailView, FormView, ListView, UpdateView
 
 from comicsdb.filters.reading_list import ReadingListViewFilter
+from comicsdb.models.character import Character
 from comicsdb.models.creator import Creator
 from comicsdb.models.credits import Credits, Role
 from comicsdb.models.issue import Issue
@@ -346,6 +347,12 @@ class ReadingListDetailView(DetailView):
                 }
                 for c in top6
             ]
+
+            context["top_characters"] = (
+                Character.objects.filter(issues__in=issue_ids)
+                .annotate(appearance_count=Count("issues", distinct=True))
+                .order_by("-appearance_count", "name")[:12]
+            )
 
         return context
 

--- a/reading_lists/views.py
+++ b/reading_lists/views.py
@@ -11,6 +11,8 @@ from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, DeleteView, DetailView, FormView, ListView, UpdateView
 
 from comicsdb.filters.reading_list import ReadingListViewFilter
+from comicsdb.models.creator import Creator
+from comicsdb.models.credits import Credits, Role
 from comicsdb.models.issue import Issue
 from comicsdb.views.mixins import LazyLoadMixin, SearchMixin
 from reading_lists.forms import (
@@ -306,6 +308,44 @@ class ReadingListDetailView(DetailView):
                 publisher_counts.values(),
                 key=lambda e: (-e["count"], e["publisher"].name),
             )
+
+            issue_ids = [item.issue_id for item in reading_list_items]
+            role_names = ["Artist", "Finishes", "Inker", "Penciller", "Script", "Story", "Writer"]
+            top6 = list(
+                Creator.objects.filter(
+                    credits__issue_id__in=issue_ids,
+                    credits__role__name__in=role_names,
+                )
+                .annotate(issue_count=Count("credits__issue", distinct=True))
+                .order_by("-issue_count", "name")[:6]
+            )
+            creator_ids = [c.id for c in top6]
+            role_map: dict[int, set[str]] = {}
+            for credit in Credits.objects.filter(
+                issue_id__in=issue_ids,
+                creator_id__in=creator_ids,
+                role__name__in=role_names,
+            ).prefetch_related(Prefetch("role", queryset=Role.objects.filter(name__in=role_names))):
+                for role in credit.role.all():
+                    role_map.setdefault(credit.creator_id, set()).add(role.name)
+            role_display = {
+                "Artist": "Artist",
+                "Finishes": "Artist",
+                "Inker": "Artist",
+                "Penciller": "Artist",
+                "Script": "Writer",
+                "Story": "Writer",
+                "Writer": "Writer",
+            }
+            context["featured_creators"] = [
+                {
+                    "creator": c,
+                    "roles": ", ".join(
+                        sorted({role_display.get(r, r) for r in role_map.get(c.id, [])})
+                    ),
+                }
+                for c in top6
+            ]
 
         return context
 


### PR DESCRIPTION
## Summary

- Redesign reading list cards with a new `rlc` card style across public, search, and user list views, adding annotated start/end year ranges derived from issue cover dates
- Enrich the reading list detail page with Featured Creators (top 6 by creative role), Featured Characters (top 12 by appearances), issue-type breakdowns (Core/Tie-In/Prologue/Epilogue), and series/publisher contribution counts
- Fix the advanced filter accordion so it no longer expands automatically after a query is submitted
