### PR TITLE
Add ability to assign reading list ownership to Metron user

### DIFF
--- a/reading_lists/README.md
+++ b/reading_lists/README.md
@@ -23,6 +23,7 @@ The Reading Lists feature allows you to create, manage, and share curated comic 
 - **Drag-and-Drop Ordering**: Easily reorder issues within your lists
 - **Smart Search**: Find issues quickly using autocomplete with series and issue number filters
 - **Attribution Tracking**: Credit sources for reading orders (admin feature)
+- **Assign to Metron**: Reassign a list's ownership to the official "Metron" account (staff / Reading List Editor feature)
 
 ### Automatic Information
 
@@ -220,6 +221,21 @@ You can rate public reading lists to help the community discover quality content
 3. Confirm the deletion
 4. The list and all its issue associations will be permanently removed
 
+### Assigning a Reading List to Metron
+
+Staff members and users in the "Reading List Editor" group can transfer ownership of any reading list (not already owned by Metron) to the official "Metron" account. This is useful for adopting community-submitted lists as official, curated reading orders.
+
+1. View the reading list's detail page
+2. Click "Assign to Metron" (only visible to staff / Reading List Editor group members, and only for lists not already owned by Metron)
+3. Confirm the ownership change on the confirmation page
+4. The list's owner is updated to "Metron"; this cannot be undone from the UI
+
+**Notes:**
+
+- This does not require being the current owner of the list
+- Once a list is owned by Metron, the "Assign to Metron" button no longer appears for it
+- After the transfer, Reading List Editor group members and staff can manage the list the same way they manage any other Metron list
+
 ## Search and Autocomplete
 
 ### Searching for Reading Lists
@@ -316,6 +332,7 @@ Admin users have additional capabilities:
 - Can set attribution sources and URLs
 - Can manage lists owned by the "Metron" user
 - Can view Metron's private lists
+- Can reassign any reading list's ownership to the "Metron" user
 
 ### Reading List Editor Group
 
@@ -323,6 +340,7 @@ Users in the "Reading List Editor" group have special permissions:
 
 - Can manage (create, edit, delete) reading lists owned by the "Metron" user
 - Can view Metron's private lists
+- Can reassign any reading list's ownership to the "Metron" user
 - Cannot set attribution sources (admin-only feature)
 - Designed for curators who maintain official reading orders
 
@@ -345,6 +363,7 @@ Some reading lists are owned by a special "Metron" user account:
 | `/reading-lists/create/` | Create a new list | Yes |
 | `/reading-lists/<slug>/update/` | Edit your list | Yes |
 | `/reading-lists/<slug>/delete/` | Delete your list | Yes |
+| `/reading-lists/<slug>/assign-to-metron/` | Reassign ownership to Metron (staff / Reading List Editor) | Yes |
 | `/reading-lists/<slug>/add-issue/` | Add issues individually | Yes |
 | `/reading-lists/<slug>/add-from-series/` | Add issues from series (bulk) | Yes |
 | `/reading-lists/<slug>/add-from-arc/` | Add issues from arc (bulk) | Yes |

--- a/reading_lists/TECHNICAL.md
+++ b/reading_lists/TECHNICAL.md
@@ -352,6 +352,35 @@ Uses same `test_func()` as UpdateView.
 
 **URL:** `/reading-lists/<slug>/delete/`
 
+#### AssignReadingListToMetronView
+
+```python
+class AssignReadingListToMetronView(LoginRequiredMixin, UserPassesTestMixin, View):
+    def test_func(self):
+        return can_assign_reading_list_to_metron(self.request.user)
+```
+
+**Purpose:** Reassigns a reading list's `user` foreign key to the "Metron" account, allowing curators to adopt community-submitted lists as official reading orders.
+
+**Permission Check:**
+
+Uses `can_assign_reading_list_to_metron()`, independent of `can_manage_reading_list()`/ownership — a user does **not** need to own or already be able to manage the list:
+
+```python
+def can_assign_reading_list_to_metron(user):
+    return user.is_staff or user.groups.filter(name="reading list editor").exists()
+```
+
+**Behavior:**
+
+1. `GET`: Renders a confirmation page (`readinglist_confirm_assign_metron.html`). If the list is already owned by Metron, redirects straight to the detail page instead.
+2. `POST`: Looks up the `CustomUser` with `username="Metron"`.
+    - If it doesn't exist, shows an error message and redirects (no exception raised).
+    - Otherwise reassigns `reading_list.user` to the Metron account, saves, and shows a success message.
+    - A no-op (but still a redirect) if the list is already Metron-owned.
+
+**URL:** `/reading-lists/<slug>/assign-to-metron/`
+
 #### AddIssueWithAutocompleteView
 ```python
 class AddIssueWithAutocompleteView(LoginRequiredMixin, UserPassesTestMixin, FormView):
@@ -592,6 +621,7 @@ urlpatterns = [
     path("<slug:slug>/", ReadingListDetailView.as_view(), name="detail"),
     path("<slug:slug>/update/", ReadingListUpdateView.as_view(), name="update"),
     path("<slug:slug>/delete/", ReadingListDeleteView.as_view(), name="delete"),
+    path("<slug:slug>/assign-to-metron/", AssignReadingListToMetronView.as_view(), name="assign-to-metron"),
     path("<slug:slug>/add-issue/", AddIssueWithAutocompleteView.as_view(), name="add-issue"),
     path("<slug:slug>/add-from-series/", AddIssuesFromSeriesView.as_view(), name="add-from-series"),
     path("<slug:slug>/add-from-arc/", AddIssuesFromArcView.as_view(), name="add-from-arc"),
@@ -735,6 +765,18 @@ A Django group created via migration that provides special permissions for manag
 - Provides elevated permissions without full admin access
 - Separates content curation from system administration
 
+### Assign-to-Metron Permission
+
+`AssignReadingListToMetronView` (used to reassign a list's ownership to the "Metron" account) uses a separate, standalone check rather than `can_manage_reading_list()`, since it must apply to lists the user does **not** already own or manage:
+
+```python
+def can_assign_reading_list_to_metron(user):
+    """Check if a user can reassign a reading list's owner to the Metron account."""
+    return user.is_staff or user.groups.filter(name="reading list editor").exists()
+```
+
+This is intentionally broader in scope (any reading list) but narrower in who qualifies (staff or Reading List Editor group members only — plain ownership does not grant this permission).
+
 ### Permission Levels
 
 **Unauthenticated Users:**
@@ -756,6 +798,7 @@ A Django group created via migration that provides special permissions for manag
 - All authenticated permissions
 - Can edit/delete Metron user's lists
 - Can view Metron's private lists
+- Can reassign any reading list (including other users' lists) to the Metron account
 - Cannot set attribution fields (admin-only)
 
 **Admin Users (is_staff=True):**
@@ -763,6 +806,7 @@ A Django group created via migration that provides special permissions for manag
 - All authenticated permissions
 - Can edit/delete Metron user's lists
 - Can view Metron's private lists
+- Can reassign any reading list (including other users' lists) to the Metron account
 - Can set attribution fields
 
 ### Visibility Rules
@@ -954,6 +998,7 @@ The web interface provides a dropdown with:
 | `readinglist_detail.html` | Single list detail | Ordered issues, add/remove controls, bulk add button |
 | `readinglist_form.html` | Create/edit form | Dynamic field visibility |
 | `readinglist_confirm_delete.html` | Delete confirmation | Issue count warning |
+| `readinglist_confirm_assign_metron.html` | Assign-to-Metron confirmation | Staff/editor-only, warns ownership change is not undoable from the UI |
 | `add_issue_autocomplete.html` | Add issues interface | Autocomplete, drag-drop, preview |
 | `add_issues_from_series.html` | Bulk add from series | Series autocomplete, HTMX range toggle, usage tips |
 | `add_issues_from_arc.html` | Bulk add from arc | Arc autocomplete, position selection, usage tips |
@@ -970,6 +1015,7 @@ The web interface provides a dropdown with:
 - `reading_list`: ReadingList instance
 - `reading_list_items`: Ordered queryset of ReadingListItem
 - `is_owner`: Boolean for edit permissions
+- `can_assign_to_metron`: Boolean; True when the current user is staff or a Reading List Editor group member and the list is not already Metron-owned. Controls visibility of the "Assign to Metron" button, independently of `is_owner`
 - `user`: Current user (from request)
 
 ### HTMX Integration
@@ -1447,13 +1493,15 @@ For complete API documentation including filtering, pagination, and response for
 - `tests/reading_lists/test_views.py`
 - `tests/reading_lists/test_forms.py`
 - `tests/reading_lists/test_models.py`
+- `tests/reading_lists/test_assign_to_metron.py`
+- `tests/reading_lists/test_reading_list_editor_group_permissions.py`
 - `tests/reading_lists/conftest.py`
 
 ### Current Test Coverage
 
 **Test Statistics:**
 
-- Total tests: 236 passing (2 skipped)
+- Total tests: 275 passing (2 skipped)
 - Forms: 100% coverage
 - Views: 94% coverage
 - Models: 99% coverage
@@ -1517,6 +1565,14 @@ For complete API documentation including filtering, pagination, and response for
     - Metron list permissions (regular users cannot edit)
     - Template rendering in display mode
     - Template rendering in edit mode
+- **Assign to Metron** (`test_assign_to_metron.py`):
+    - Permission checks (staff, Reading List Editor group, regular users, list owners without staff/editor status)
+    - Confirm-page rendering and redirect-when-already-Metron-owned behavior
+    - Ownership transfer on POST, and no-op behavior when already Metron-owned
+    - Anonymous users redirected to login
+    - Detail view `can_assign_to_metron` context flag and button visibility
+    - Graceful failure when the "Metron" account does not exist
+    - Direct tests of the `can_assign_reading_list_to_metron()` helper
 
 **Form Tests:**
 
@@ -1595,6 +1651,11 @@ class ReadingListModelTest(TestCase):
     - Reading List Editor group
     - Manage Metron user's lists without admin access
     - Curator role for official reading orders
+
+- ✅ **Assign to Metron** (Implemented)
+    - Staff and Reading List Editor group members can reassign any reading list's ownership to the "Metron" account
+    - Dedicated confirmation page before the (one-way) ownership change
+    - Standalone permission check independent of list ownership
 
 - ✅ **Import Management Command** (Implemented)
     - Bulk import from JSON files

--- a/reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html
+++ b/reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html
@@ -1,0 +1,44 @@
+{% extends parent_template|default:"base.html" %}
+{% load static %}
+{% block title %}Assign {{ reading_list.name }} to Metron - Metron{% endblock %}
+{% block content %}
+    <header class="block has-text-centered">
+        <h1 class="title">Assign Reading List to Metron</h1>
+    </header>
+    <section class="section">
+        <div class="container">
+            <div class="columns is-centered">
+                <div class="column is-half">
+                    <div class="box">
+                        <article class="message is-warning">
+                            <div class="message-header">
+                                <p>Confirm ownership change</p>
+                            </div>
+                            <div class="message-body">
+                                <p class="mb-3">
+                                    Are you sure you want to reassign ownership of the reading list
+                                    <strong>"{{ reading_list.name }}"</strong> from
+                                    <strong>{{ reading_list.user.username }}</strong> to the
+                                    <strong>Metron</strong> account?
+                                </p>
+                                <p>This action cannot be undone from this page.</p>
+                            </div>
+                        </article>
+                        <form method="post">
+                            {% csrf_token %}
+                            <div class="field is-grouped is-grouped-right">
+                                <div class="control">
+                                    <a href="{% url 'reading-list:detail' reading_list.slug %}"
+                                       class="button">Cancel</a>
+                                </div>
+                                <div class="control">
+                                    <button type="submit" class="button is-warning">Assign to Metron</button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/reading_lists/templates/reading_lists/readinglist_detail.html
+++ b/reading_lists/templates/reading_lists/readinglist_detail.html
@@ -120,31 +120,40 @@
     </div>
 
     {# ===================== OWNER ACTION BAR ===================== #}
-    {% if is_owner %}
+    {% if is_owner or can_assign_to_metron %}
         <nav class="level mb-5">
             <div class="level-left"></div>
             <div class="level-right">
                 <div class="buttons">
-                    <a class="button is-primary" href="{% url 'reading-list:add-issue' reading_list.slug %}">
-                        <span class="icon is-small"><i class="fas fa-plus"></i></span>
-                        <span>Add Issues</span>
-                    </a>
-                    <a class="button is-primary is-light" href="{% url 'reading-list:add-from-series' reading_list.slug %}">
-                        <span class="icon is-small"><i class="fas fa-layer-group"></i></span>
-                        <span>Add from Series</span>
-                    </a>
-                    <a class="button is-primary is-light" href="{% url 'reading-list:add-from-arc' reading_list.slug %}">
-                        <span class="icon is-small"><i class="fas fa-book"></i></span>
-                        <span>Add from Arc</span>
-                    </a>
-                    <a class="button is-info" href="{% url 'reading-list:update' reading_list.slug %}">
-                        <span class="icon is-small"><i class="fas fa-edit"></i></span>
-                        <span>Edit</span>
-                    </a>
-                    <a class="button is-danger" href="{% url 'reading-list:delete' reading_list.slug %}">
-                        <span class="icon is-small"><i class="fas fa-trash"></i></span>
-                        <span>Delete</span>
-                    </a>
+                    {% if is_owner %}
+                        <a class="button is-primary" href="{% url 'reading-list:add-issue' reading_list.slug %}">
+                            <span class="icon is-small"><i class="fas fa-plus"></i></span>
+                            <span>Add Issues</span>
+                        </a>
+                        <a class="button is-primary is-light" href="{% url 'reading-list:add-from-series' reading_list.slug %}">
+                            <span class="icon is-small"><i class="fas fa-layer-group"></i></span>
+                            <span>Add from Series</span>
+                        </a>
+                        <a class="button is-primary is-light" href="{% url 'reading-list:add-from-arc' reading_list.slug %}">
+                            <span class="icon is-small"><i class="fas fa-book"></i></span>
+                            <span>Add from Arc</span>
+                        </a>
+                        <a class="button is-info" href="{% url 'reading-list:update' reading_list.slug %}">
+                            <span class="icon is-small"><i class="fas fa-edit"></i></span>
+                            <span>Edit</span>
+                        </a>
+                        <a class="button is-danger" href="{% url 'reading-list:delete' reading_list.slug %}">
+                            <span class="icon is-small"><i class="fas fa-trash"></i></span>
+                            <span>Delete</span>
+                        </a>
+                    {% endif %}
+                    {% if can_assign_to_metron %}
+                        <a class="button is-warning is-outlined"
+                           href="{% url 'reading-list:assign-to-metron' reading_list.slug %}">
+                            <span class="icon is-small"><i class="fas fa-user-shield"></i></span>
+                            <span>Assign to Metron</span>
+                        </a>
+                    {% endif %}
                 </div>
             </div>
         </nav>

--- a/reading_lists/urls.py
+++ b/reading_lists/urls.py
@@ -4,6 +4,7 @@ from reading_lists.views import (
     AddIssuesFromArcView,
     AddIssuesFromSeriesView,
     AddIssueWithAutocompleteView,
+    AssignReadingListToMetronView,
     ReadingListCreateView,
     ReadingListDeleteView,
     ReadingListDetailView,
@@ -28,6 +29,11 @@ urlpatterns = [
     path("<slug:slug>/", ReadingListDetailView.as_view(), name="detail"),
     path("<slug:slug>/update/", ReadingListUpdateView.as_view(), name="update"),
     path("<slug:slug>/delete/", ReadingListDeleteView.as_view(), name="delete"),
+    path(
+        "<slug:slug>/assign-to-metron/",
+        AssignReadingListToMetronView.as_view(),
+        name="assign-to-metron",
+    ),
     path(
         "<slug:slug>/add-issue/",
         AddIssueWithAutocompleteView.as_view(),

--- a/reading_lists/views.py
+++ b/reading_lists/views.py
@@ -114,6 +114,14 @@ def can_manage_reading_list(user, reading_list):
     return is_owner
 
 
+def can_assign_reading_list_to_metron(user):
+    """Check if a user can reassign a reading list's owner to the Metron account.
+
+    Allowed for staff or members of the 'reading list editor' group.
+    """
+    return user.is_staff or user.groups.filter(name="reading list editor").exists()
+
+
 class ReadingListListView(ListView):
     """Display all public reading lists, plus user's own lists if authenticated."""
 
@@ -315,8 +323,12 @@ class ReadingListDetailView(DetailView):
         # Check if user can manage this reading list
         if self.request.user.is_authenticated:
             context["is_owner"] = can_manage_reading_list(self.request.user, reading_list)
+            context["can_assign_to_metron"] = reading_list.user.username != "Metron" and (
+                can_assign_reading_list_to_metron(self.request.user)
+            )
         else:
             context["is_owner"] = False
+            context["can_assign_to_metron"] = False
 
         # Get user's rating from prefetched data
         user_rating = None
@@ -507,6 +519,43 @@ class ReadingListDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView)
     def form_valid(self, form):
         messages.success(self.request, f"Reading list '{self.object.name}' deleted!")
         return super().form_valid(form)
+
+
+class AssignReadingListToMetronView(LoginRequiredMixin, UserPassesTestMixin, View):
+    """Reassign a reading list's owner to the Metron account."""
+
+    def dispatch(self, request, *args, **kwargs):
+        self.reading_list = get_object_or_404(ReadingList, slug=kwargs["slug"])
+        return super().dispatch(request, *args, **kwargs)
+
+    def test_func(self):
+        """Only allow staff or 'reading list editor' group members."""
+        return can_assign_reading_list_to_metron(self.request.user)
+
+    def get(self, request, *args, **kwargs):
+        if self.reading_list.user.username == "Metron":
+            return redirect(self.reading_list.get_absolute_url())
+        return render(
+            request,
+            "reading_lists/readinglist_confirm_assign_metron.html",
+            {"reading_list": self.reading_list},
+        )
+
+    def post(self, request, *args, **kwargs):
+        try:
+            metron_user = CustomUser.objects.get(username="Metron")
+        except CustomUser.DoesNotExist:
+            messages.error(request, "The 'Metron' user account does not exist.")
+            return redirect(self.reading_list.get_absolute_url())
+
+        if self.reading_list.user_id != metron_user.id:
+            self.reading_list.user = metron_user
+            self.reading_list.save()
+            messages.success(
+                request,
+                f"Ownership of '{self.reading_list.name}' has been reassigned to Metron.",
+            )
+        return redirect(self.reading_list.get_absolute_url())
 
 
 class RemoveIssueFromReadingListView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):

--- a/tests/reading_lists/test_assign_to_metron.py
+++ b/tests/reading_lists/test_assign_to_metron.py
@@ -1,0 +1,164 @@
+"""Tests for reassigning a reading list's owner to the Metron account."""
+
+from django.urls import reverse
+
+from reading_lists.views import can_assign_reading_list_to_metron
+
+HTTP_200_OK = 200
+HTTP_302_FOUND = 302
+HTTP_403_FORBIDDEN = 403
+
+
+class TestAssignReadingListToMetron:
+    """Tests for the 'assign to Metron' ownership-transfer action."""
+
+    def test_editor_can_view_confirm_page(
+        self, client, reading_list_editor_user, public_reading_list, test_password
+    ):
+        """Reading list editors can view the confirm page for another user's list."""
+        client.login(username=reading_list_editor_user.username, password=test_password)
+        url = reverse("reading-list:assign-to-metron", args=[public_reading_list.slug])
+        resp = client.get(url)
+        assert resp.status_code == HTTP_200_OK
+        assert resp.context["reading_list"] == public_reading_list
+
+    def test_editor_can_assign_other_user_list_to_metron(
+        self,
+        client,
+        reading_list_editor_user,
+        public_reading_list,
+        metron_user,
+        test_password,
+    ):
+        """Reading list editors can reassign another user's list to Metron."""
+        client.login(username=reading_list_editor_user.username, password=test_password)
+        url = reverse("reading-list:assign-to-metron", args=[public_reading_list.slug])
+        resp = client.post(url)
+        assert resp.status_code == HTTP_302_FOUND
+        public_reading_list.refresh_from_db()
+        assert public_reading_list.user == metron_user
+
+    def test_staff_can_assign_other_user_list_to_metron(
+        self,
+        client,
+        admin_user,
+        public_reading_list,
+        metron_user,
+        test_password,
+    ):
+        """Staff (not necessarily in the editor group) can reassign lists to Metron."""
+        client.login(username=admin_user.username, password=test_password)
+        url = reverse("reading-list:assign-to-metron", args=[public_reading_list.slug])
+        resp = client.post(url)
+        assert resp.status_code == HTTP_302_FOUND
+        public_reading_list.refresh_from_db()
+        assert public_reading_list.user == metron_user
+
+    def test_regular_user_cannot_assign_list_to_metron(
+        self, client, other_user, public_reading_list, test_password
+    ):
+        """A regular authenticated user without staff/editor status is forbidden."""
+        client.login(username=other_user.username, password=test_password)
+        url = reverse("reading-list:assign-to-metron", args=[public_reading_list.slug])
+        resp = client.post(url)
+        assert resp.status_code == HTTP_403_FORBIDDEN
+        public_reading_list.refresh_from_db()
+        assert public_reading_list.user.username != "Metron"
+
+    def test_owner_without_editor_group_cannot_assign_own_list(
+        self, client, reading_list_user, public_reading_list, test_password
+    ):
+        """Owning the list alone does not grant permission to reassign it to Metron."""
+        client.login(username=reading_list_user.username, password=test_password)
+        url = reverse("reading-list:assign-to-metron", args=[public_reading_list.slug])
+        resp = client.post(url)
+        assert resp.status_code == HTTP_403_FORBIDDEN
+
+    def test_anonymous_user_redirected_to_login(self, client, public_reading_list):
+        """Anonymous users are redirected to login."""
+        url = reverse("reading-list:assign-to-metron", args=[public_reading_list.slug])
+        resp = client.get(url)
+        assert resp.status_code == HTTP_302_FOUND
+        assert "/accounts/login/" in resp.url
+
+    def test_get_redirects_when_already_owned_by_metron(
+        self, client, reading_list_editor_user, metron_reading_list, test_password
+    ):
+        """The confirm page redirects if the list is already owned by Metron."""
+        client.login(username=reading_list_editor_user.username, password=test_password)
+        url = reverse("reading-list:assign-to-metron", args=[metron_reading_list.slug])
+        resp = client.get(url)
+        assert resp.status_code == HTTP_302_FOUND
+        assert resp.url == metron_reading_list.get_absolute_url()
+
+    def test_post_is_noop_when_already_owned_by_metron(
+        self, client, reading_list_editor_user, metron_reading_list, metron_user, test_password
+    ):
+        """Posting on an already-Metron-owned list leaves the owner unchanged."""
+        client.login(username=reading_list_editor_user.username, password=test_password)
+        url = reverse("reading-list:assign-to-metron", args=[metron_reading_list.slug])
+        resp = client.post(url)
+        assert resp.status_code == HTTP_302_FOUND
+        metron_reading_list.refresh_from_db()
+        assert metron_reading_list.user == metron_user
+
+    def test_detail_view_shows_button_for_editor_on_other_user_list(
+        self, client, reading_list_editor_user, public_reading_list, test_password
+    ):
+        """The detail view context flags the action as available for editors."""
+        client.login(username=reading_list_editor_user.username, password=test_password)
+        url = reverse("reading-list:detail", args=[public_reading_list.slug])
+        resp = client.get(url)
+        assert resp.status_code == HTTP_200_OK
+        assert resp.context["can_assign_to_metron"] is True
+        assert b"Assign to Metron" in resp.content
+
+    def test_detail_view_hides_button_for_regular_user(
+        self, client, other_user, public_reading_list, test_password
+    ):
+        """The detail view hides the action for users without staff/editor status."""
+        client.login(username=other_user.username, password=test_password)
+        url = reverse("reading-list:detail", args=[public_reading_list.slug])
+        resp = client.get(url)
+        assert resp.status_code == HTTP_200_OK
+        assert resp.context["can_assign_to_metron"] is False
+        assert b"Assign to Metron" not in resp.content
+
+    def test_detail_view_hides_button_when_already_metron_owned(
+        self, client, reading_list_editor_user, metron_reading_list, test_password
+    ):
+        """The detail view hides the action once the list is already Metron-owned."""
+        client.login(username=reading_list_editor_user.username, password=test_password)
+        url = reverse("reading-list:detail", args=[metron_reading_list.slug])
+        resp = client.get(url)
+        assert resp.status_code == HTTP_200_OK
+        assert resp.context["can_assign_to_metron"] is False
+
+    def test_missing_metron_user_shows_error(
+        self, client, reading_list_editor_user, public_reading_list, metron_user, test_password
+    ):
+        """If the Metron account doesn't exist, the POST fails gracefully."""
+        metron_user.username = "not-metron"
+        metron_user.save()
+
+        client.login(username=reading_list_editor_user.username, password=test_password)
+        url = reverse("reading-list:assign-to-metron", args=[public_reading_list.slug])
+        resp = client.post(url, follow=True)
+        assert resp.status_code == HTTP_200_OK
+        messages = list(resp.context["messages"])
+        assert any("does not exist" in str(m) for m in messages)
+        public_reading_list.refresh_from_db()
+        assert public_reading_list.user.username != "not-metron"
+
+
+class TestCanAssignReadingListToMetronHelper:
+    """Direct tests for the permission helper function."""
+
+    def test_staff_user_can_assign(self, admin_user):
+        assert can_assign_reading_list_to_metron(admin_user) is True
+
+    def test_editor_group_user_can_assign(self, reading_list_editor_user):
+        assert can_assign_reading_list_to_metron(reading_list_editor_user) is True
+
+    def test_regular_user_cannot_assign(self, other_user):
+        assert can_assign_reading_list_to_metron(other_user) is False


### PR DESCRIPTION
## Summary

- Adds an "Assign to Metron" action on the reading list detail view that lets staff or members of the "reading list editor" group reassign ownership of a reading list to the Metron account
- The action is gated behind a confirmation page (matching the existing delete-confirmation style) and is a one-way transfer
- The button is hidden once a list is already owned by Metron, and is available independently of the existing owner-only action bar (add issues/edit/delete)

Closes #552
