### PR TITLE
Add rating-only update endpoint to Collection API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -797,6 +797,8 @@ User comic book collections with tracking for ownership, grading, reading status
 
 - `GET /api/collection/` - List authenticated user's collection items
 - `GET /api/collection/{id}/` - Retrieve collection item details (must belong to user)
+- `PATCH /api/collection/{id}/` - Update a collection item's rating (must belong to user)
+- `PUT /api/collection/{id}/` - Update a collection item's rating (must belong to user)
 - `GET /api/collection/stats/` - Get collection statistics
 - `GET /api/collection/missing_series/` - Get series where user has incomplete runs
 - `GET /api/collection/missing_issues/{series_id}/` - Get specific missing issues for a series
@@ -804,7 +806,7 @@ User comic book collections with tracking for ownership, grading, reading status
 
 **Collection Management:**
 
-Most collection operations are managed through the web interface. The API provides read access plus the scrobble endpoint for marking issues as read.
+Most collection operations are managed through the web interface. The API provides read access, a rating-only update endpoint, and the scrobble endpoint for marking issues as read.
 
 **Authentication:**
 
@@ -1277,6 +1279,71 @@ curl -X POST https://metron.cloud/api/collection/scrobble/ \
 
 ---
 
+#### Update Rating Endpoint
+
+A minimal update endpoint for changing a collection item's personal rating without touching read-tracking data.
+
+**Endpoint:** `PATCH /api/collection/{id}/` (or `PUT /api/collection/{id}/`)
+
+**Purpose:**
+
+- Set or change the star rating on an existing collection item
+- Does not create, modify, or remove any `read_dates` entries
+- Does not affect `is_read` or `date_read` - use the [scrobble endpoint](#scrobble-endpoint) for read tracking
+
+**Request Body:**
+
+```json
+{
+  "rating": 5
+}
+```
+
+**Request Fields:**
+
+- `rating` - The only editable field. Star rating from 1-5, or `null` to clear the rating.
+
+Any other fields included in the request body (e.g. `is_read`, `date_read`, `quantity`) are ignored - this endpoint only accepts `rating`.
+
+**Response (200 OK):**
+
+```json
+{
+  "id": 789,
+  "rating": 5,
+  "modified": "2026-01-08T14:30:00Z"
+}
+```
+
+**Status Codes:**
+
+- `200 OK` - Rating was updated
+- `400 Bad Request` - Validation error (rating out of range)
+- `401 Unauthorized` - Authentication required
+- `404 Not Found` - Collection item doesn't exist or doesn't belong to the authenticated user
+
+**Examples:**
+
+```bash
+# Set a rating
+curl -X PATCH https://metron.cloud/api/collection/789/ \
+  -u "username:password" \
+  -H "Content-Type: application/json" \
+  -d '{"rating": 5}'
+
+# Clear a rating
+curl -X PATCH https://metron.cloud/api/collection/789/ \
+  -u "username:password" \
+  -H "Content-Type: application/json" \
+  -d '{"rating": null}'
+```
+
+**Validation:**
+
+- `rating` must be between 1 and 5 (inclusive), or `null`
+
+---
+
 **Notes:**
 
 - Collection items are private - each user can only access their own collection
@@ -1286,6 +1353,7 @@ curl -X POST https://metron.cloud/api/collection/scrobble/ \
 - Format counts in stats show the raw choice value (PRINT, DIGITAL, BOTH) not the display name
 - Multiple read dates are supported - comics can be re-read and each read is tracked separately
 - The `is_read` and `date_read` fields are automatically synchronized from the `read_dates` array
+- Read tracking (`is_read`, `date_read`, `read_dates`) is only writable through the [scrobble endpoint](#scrobble-endpoint); the collection update endpoint only accepts `rating`
 
 ---
 

--- a/api/v1_0/serializers/__init__.py
+++ b/api/v1_0/serializers/__init__.py
@@ -54,6 +54,7 @@ from api.v1_0.serializers.reading_list import (
 )
 from api.v1_0.serializers.collection import (
     CollectionListSerializer,
+    CollectionRatingUpdateSerializer,
     CollectionReadSerializer,
     MissingIssueSerializer,
     MissingSeriesSerializer,
@@ -71,6 +72,7 @@ __all__ = [
     "CharacterReadSerializer",
     "CharacterSerializer",
     "CollectionListSerializer",
+    "CollectionRatingUpdateSerializer",
     "CollectionReadSerializer",
     "CreatorListSerializer",
     "CreatorSerializer",

--- a/api/v1_0/serializers/collection.py
+++ b/api/v1_0/serializers/collection.py
@@ -62,6 +62,19 @@ class CollectionListSerializer(serializers.ModelSerializer):
         )
 
 
+class CollectionRatingUpdateSerializer(serializers.ModelSerializer):
+    """Update serializer for collection items - rating only.
+
+    Read-tracking (is_read/date_read) is handled exclusively through the
+    scrobble action, so this serializer intentionally excludes those fields.
+    """
+
+    class Meta:
+        model = CollectionItem
+        fields = ("id", "rating", "modified")
+        read_only_fields = ("id", "modified")
+
+
 class CollectionReadSerializer(serializers.ModelSerializer):
     """Read serializer for collection items - full detail view."""
 

--- a/api/views.py
+++ b/api/views.py
@@ -20,6 +20,7 @@ from api.v1_0.serializers import (
     CharacterReadSerializer,
     CharacterSerializer,
     CollectionListSerializer,
+    CollectionRatingUpdateSerializer,
     CollectionReadSerializer,
     CreatorListSerializer,
     CreatorSerializer,
@@ -707,6 +708,7 @@ class VariantViewset(
 class CollectionViewSet(
     ConditionalRetrieveModelMixin,
     mixins.ListModelMixin,
+    mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
 ):
     """
@@ -716,6 +718,16 @@ class CollectionViewSet(
 
     retrieve:
     Returns details of a specific collection item (must belong to authenticated user).
+    Requires authentication.
+
+    partial_update:
+    Update the rating of a specific collection item (must belong to authenticated user).
+    Read-tracking fields (is_read/date_read) are not editable here; use scrobble instead.
+    Requires authentication.
+
+    update:
+    Update the rating of a specific collection item (must belong to authenticated user).
+    Read-tracking fields (is_read/date_read) are not editable here; use scrobble instead.
     Requires authentication.
     """
 
@@ -733,6 +745,8 @@ class CollectionViewSet(
     def get_serializer_class(self):
         if self.action == "list":
             return CollectionListSerializer
+        if self.action in ("update", "partial_update"):
+            return CollectionRatingUpdateSerializer
         return CollectionReadSerializer
 
     @extend_schema(

--- a/tests/user_collection/test_collection_update.py
+++ b/tests/user_collection/test_collection_update.py
@@ -1,0 +1,109 @@
+"""Tests for PATCH/PUT updates on Collection API (rating only)."""
+
+from django.urls import reverse
+from rest_framework import status
+
+from user_collection.models import CollectionItem, ReadDate
+
+
+def test_unauthenticated_update_requires_auth(api_client, collection_item):
+    """Unauthenticated users require authentication to update a collection item."""
+    resp = api_client.patch(
+        reverse("api:collection-detail", args=[collection_item.id]),
+        {"rating": 4},
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_patch_updates_rating(api_client, collection_user, collection_item):
+    """PATCH updates the rating field."""
+    api_client.force_authenticate(user=collection_user)
+
+    resp = api_client.patch(
+        reverse("api:collection-detail", args=[collection_item.id]),
+        {"rating": 4},
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["rating"] == 4
+
+    collection_item.refresh_from_db()
+    assert collection_item.rating == 4
+
+
+def test_patch_rating_creates_no_read_date_rows(api_client, collection_user, collection_item):
+    """Updating rating via PATCH does not create any ReadDate rows."""
+    api_client.force_authenticate(user=collection_user)
+
+    assert ReadDate.objects.filter(collection_item=collection_item).count() == 0
+
+    api_client.patch(
+        reverse("api:collection-detail", args=[collection_item.id]),
+        {"rating": 5},
+    )
+
+    assert ReadDate.objects.filter(collection_item=collection_item).count() == 0
+
+
+def test_patch_ignores_is_read_and_date_read(api_client, collection_user, collection_item):
+    """is_read/date_read in the PATCH body are ignored; only rating is applied."""
+    api_client.force_authenticate(user=collection_user)
+
+    collection_item.is_read = False
+    collection_item.date_read = None
+    collection_item.save()
+
+    resp = api_client.patch(
+        reverse("api:collection-detail", args=[collection_item.id]),
+        {"rating": 3, "is_read": True, "date_read": "2024-06-15T14:30:00Z"},
+    )
+    assert resp.status_code == status.HTTP_200_OK
+
+    collection_item.refresh_from_db()
+    assert collection_item.rating == 3
+    assert collection_item.is_read is False
+    assert collection_item.date_read is None
+
+
+def test_patch_rating_below_min_returns_400(api_client, collection_user, collection_item):
+    """Rating < 1 returns 400."""
+    api_client.force_authenticate(user=collection_user)
+
+    resp = api_client.patch(
+        reverse("api:collection-detail", args=[collection_item.id]),
+        {"rating": 0},
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert "rating" in resp.data
+
+
+def test_patch_rating_above_max_returns_400(api_client, collection_user, collection_item):
+    """Rating > 5 returns 400."""
+    api_client.force_authenticate(user=collection_user)
+
+    resp = api_client.patch(
+        reverse("api:collection-detail", args=[collection_item.id]),
+        {"rating": 6},
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert "rating" in resp.data
+
+
+def test_patch_other_users_collection_item_returns_404(
+    api_client, collection_user, other_collection_user, collection_issue_1
+):
+    """A user cannot update another user's collection item."""
+    other_item = CollectionItem.objects.create(
+        user=other_collection_user,
+        issue=collection_issue_1,
+        quantity=1,
+    )
+
+    api_client.force_authenticate(user=collection_user)
+    resp = api_client.patch(
+        reverse("api:collection-detail", args=[other_item.id]),
+        {"rating": 5},
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    other_item.refresh_from_db()
+    assert other_item.rating is None


### PR DESCRIPTION
## Summary
- Add `PATCH`/`PUT /api/collection/{id}/` support via a new `CollectionRatingUpdateSerializer` that only accepts `rating`, so read-tracking (`is_read`/`date_read`/`read_dates`) stays exclusively managed through the scrobble endpoint.
- `CollectionViewSet` now includes `UpdateModelMixin`, routed to the rating-only serializer for `update`/`partial_update`; ownership scoping is unchanged (`get_queryset()` already filters to the authenticated user, so updating another user's item 404s).
- Document the new endpoint in `api/README.md` alongside the existing Collection/Scrobble sections.
