### PR TITLE
Add UPC prefix filter for mobile barcode scanning

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -328,6 +328,7 @@ The Issue endpoint supports the most comprehensive filtering options:
 - `alt_number` - Alternate number (case-insensitive, exact match)
 - `sku` - Distributor SKU (exact match)
 - `upc` - UPC code (exact match)
+- `upc_starts_with` - UPC code prefix match. Useful for mobile barcode scanners (e.g. Google ML Kit, AVFoundation) that only read the 12-digit UPC-A and drop the 5-digit EAN supplemental — pass just those 12 digits to match issues whose stored `upc` begins with them.
 - `cv_id` - Comic Vine ID
 - `gcd_id` - Grand Comics Database ID
 - `missing_cv_id` - Boolean, issues without Comic Vine ID
@@ -429,6 +430,9 @@ GET /api/issue/?cover_year=2024&cover_month=12
 
 # Find by UPC
 GET /api/issue/?upc=75960609558200111
+
+# Find by the 12-digit UPC-A from a mobile barcode scanner (no EAN supplemental)
+GET /api/issue/?upc_starts_with=759606095582
 
 # Get all issues with a credit for a specific creator
 GET /api/issue/?creator_id=123

--- a/comicsdb/filters/issue.py
+++ b/comicsdb/filters/issue.py
@@ -70,6 +70,12 @@ class IssueFilter(df.rest_framework.FilterSet):
         label="Distributor SKU", field_name="sku", lookup_expr="iexact"
     )
     upc = df.rest_framework.CharFilter(label="UPC Code", field_name="upc", lookup_expr="iexact")
+    upc_starts_with = df.rest_framework.CharFilter(
+        label="UPC Code starts with (e.g. the 12-digit UPC-A read by a mobile scanner "
+        "that strips the 5-digit EAN supplemental)",
+        field_name="upc",
+        lookup_expr="startswith",
+    )
     cv_id = df.rest_framework.NumberFilter(
         label="Comic Vine ID", field_name="cv_id", lookup_expr="exact"
     )

--- a/tests/comicsdb/test_api_issue.py
+++ b/tests/comicsdb/test_api_issue.py
@@ -352,3 +352,24 @@ def test_filter_by_multiple_role_ids(
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["count"] == 1
     assert resp.data["results"][0]["id"] == basic_issue.id
+
+
+def test_filter_by_upc_starts_with(api_client_with_credentials, basic_issue: Issue):
+    basic_issue.upc = "76194137738400111"
+    basic_issue.save()
+    resp = api_client_with_credentials.get(
+        reverse("api:issue-list"), {"upc_starts_with": "761941377384"}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == basic_issue.id
+
+
+def test_filter_by_upc_starts_with_no_match(api_client_with_credentials, basic_issue: Issue):
+    basic_issue.upc = "76194137738400111"
+    basic_issue.save()
+    resp = api_client_with_credentials.get(
+        reverse("api:issue-list"), {"upc_starts_with": "000000000000"}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["count"] == 0


### PR DESCRIPTION
## Summary
- Add a `upc_starts_with` filter to `IssueFilter` for the `/api/issue/` endpoint, matching issues whose `upc` field starts with the given value
- Mobile camera barcode-scanning frameworks (Google ML Kit on Android, AVFoundation on iOS) read the 12-digit UPC-A but strip the 5-digit EAN supplemental, so exact `upc` matches fail for scanned codes — this lets clients search with just the 12 digits they have
- Document the new filter parameter and add a usage example in `api/README.md`

Closes #562 