### PR TITLE
Add timeline entry for OpenCollective donor rate limits

### DIFF
--- a/timeline/entries/2026-07-16_supporter_rate_limits.md
+++ b/timeline/entries/2026-07-16_supporter_rate_limits.md
@@ -1,0 +1,10 @@
+---
+title: Donor-based API rate limits
+date: Jul 16th, 2026
+icon: fa fa-tachometer-alt
+icon_color: pastel-blue
+---
+
+The project now automatically grants elevated API rate limits to [OpenCollective](https://opencollective.com/metron) donors, with no separate signup required. Donations are synced hourly and matched to Metron accounts by confirmed email address, unlocking tiers up to 25,000 daily requests for Mega Sponsors, well above the standard 5,000 request limit.
+
+Read the full announcement on the [Metron blog](https://metron-project.github.io/blog/supporter-rate-limits).


### PR DESCRIPTION
This PR simply add a timeline entry for the  OpenCollective donor rate limits.