### PR TITLE
Prevent rating issues with a future store_date

### DIFF
--- a/comicsdb/models/issue.py
+++ b/comicsdb/models/issue.py
@@ -102,6 +102,10 @@ class Issue(CommonInfo):
     def is_foc_past_due(self) -> bool:
         return self.foc_date is not None and date.today() > self.foc_date
 
+    @property
+    def is_released(self) -> bool:
+        return self.store_date is None or date.today() >= self.store_date
+
     def save(self, *args, **kwargs) -> None:
         # Let's delete the original image if we're replacing it by uploading a new one.
         with contextlib.suppress(ObjectDoesNotExist):

--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -630,7 +630,7 @@
                     {% endif %}
                 {% endwith %}
                 <hr>
-                {% include "partials/rating_widget.html" with rated_object=issue rate_url_name="issue-ratings:rate" rate_url_arg=issue.pk user_rating=user_rating average_rating=average_rating rating_count=rating_count show_ratings=True can_rate=user.is_authenticated %}
+                {% include "partials/rating_widget.html" with rated_object=issue rate_url_name="issue-ratings:rate" rate_url_arg=issue.pk user_rating=user_rating average_rating=average_rating rating_count=rating_count show_ratings=True can_rate=can_rate %}
             </div>
             <div class="box">
                 <h2 class="title is-6">Identification Numbers</h2>

--- a/comicsdb/views/issue.py
+++ b/comicsdb/views/issue.py
@@ -211,6 +211,7 @@ class IssueDetail(DetailView):
                 user=self.request.user,
             ).first()
 
+        context["can_rate"] = self.request.user.is_authenticated and issue.is_released
         context["average_rating"] = issue.average_rating
         context["rating_count"] = issue.rating_count
 

--- a/issue_ratings/views.py
+++ b/issue_ratings/views.py
@@ -16,11 +16,12 @@ def update_issue_rating(request, pk):
     """HTMX view to update the rating of an issue."""
     issue = get_object_or_404(Issue, pk=pk)
 
-    apply_rating_update(
-        IssueRating,
-        {"issue": issue, "user": request.user},
-        request.POST.get("rating"),
-    )
+    if issue.is_released:
+        apply_rating_update(
+            IssueRating,
+            {"issue": issue, "user": request.user},
+            request.POST.get("rating"),
+        )
 
     # Get user's current rating and average
     user_rating = IssueRating.objects.filter(
@@ -46,7 +47,7 @@ def update_issue_rating(request, pk):
             "average_rating": avg_data["avg"],
             "rating_count": avg_data["count"],
             "show_ratings": True,
-            "can_rate": True,
+            "can_rate": issue.is_released,
         },
         request=request,
     )

--- a/tests/comicsdb/test_models.py
+++ b/tests/comicsdb/test_models.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from comicsdb.models import (
     Announcement,
     Arc,
@@ -153,6 +155,18 @@ def test_series_absolute_url(auto_login_user, fc_series):
 def test_issue_creation(issue_with_arc):
     assert isinstance(issue_with_arc, Issue)
     assert str(issue_with_arc) == "Final Crisis (1939) #1"
+
+
+def test_issue_is_released_no_store_date():
+    assert Issue(store_date=None).is_released is True
+
+
+def test_issue_is_released_past_store_date():
+    assert Issue(store_date=date(2000, 1, 1)).is_released is True
+
+
+def test_issue_is_released_future_store_date():
+    assert Issue(store_date=date(2999, 1, 1)).is_released is False
 
 
 def test_issue_verbose_name_plural(issue_with_arc):

--- a/tests/issue_ratings/conftest.py
+++ b/tests/issue_ratings/conftest.py
@@ -59,3 +59,18 @@ def rating_issue(create_user, rating_series):
         edited_by=user,
         created_by=user,
     )
+
+
+@pytest.fixture
+def future_rating_issue(create_user, rating_series):
+    """Create an issue with a future store_date for issue rating tests."""
+    user = create_user()
+    return Issue.objects.create(
+        series=rating_series,
+        number="2",
+        slug="rating-test-series-2",
+        cover_date=date(2999, 1, 1),
+        store_date=date(2999, 1, 1),
+        edited_by=user,
+        created_by=user,
+    )

--- a/tests/issue_ratings/test_views.py
+++ b/tests/issue_ratings/test_views.py
@@ -72,6 +72,17 @@ class TestIssueRating:
         assert resp.status_code == HTTP_200_OK
         assert not IssueRating.objects.filter(issue=rating_issue, user=rating_user).exists()
 
+    def test_update_rating_rejects_future_store_date(
+        self, client, future_rating_issue, test_password, rating_user
+    ):
+        """Test that rating an issue with a future store_date is a no-op."""
+        client.login(username=rating_user.username, password=test_password)
+        url = reverse("issue-ratings:rate", kwargs={"pk": future_rating_issue.pk})
+
+        resp = client.post(url, data={"rating": "5"})
+        assert resp.status_code == HTTP_200_OK
+        assert not IssueRating.objects.filter(issue=future_rating_issue, user=rating_user).exists()
+
     def test_average_rating_calculation(self, rating_issue, create_user):
         """Test that average rating is calculated correctly."""
         user1 = create_user(username="avg_user1")


### PR DESCRIPTION
## Summary
- Add an `Issue.is_released` property (mirrors the existing `is_foc_past_due` pattern) that treats a null `store_date` as released but a future `store_date` as not yet released.
- Guard the HTMX rating view (`issue_ratings/views.py`) so POSTing a rating to an unreleased issue is a no-op, and hide the interactive star widget for unreleased issues on the issue detail page via a `can_rate` context flag (computed the same way `reading_lists` already does).
