### PR TITLE
Add series alt_names to Issue serializer

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -381,6 +381,7 @@ The Issue endpoint supports the most comprehensive filtering options:
 
 - All list fields plus:
     - `desc` - Issue description
+    - `series` - Expanded compared to the list view, adding `sort_name`, `series_type` (object with `id`/`name`), `genres` (array of genre objects), and `alt_names` (array of alternate series names)
     - `price` - Cover price amount as a decimal string (e.g. `"3.99"`). See `price_currency` for the currency.
     - `price_currency` - ISO 4217 currency code for the cover price (e.g. `"USD"`, `"GBP"`).
     - `sku` - Distributor SKU

--- a/api/v1_0/serializers/issue.py
+++ b/api/v1_0/serializers/issue.py
@@ -145,7 +145,16 @@ class IssueSeriesSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Series
-        fields = ("id", "name", "sort_name", "volume", "year_began", "series_type", "genres")
+        fields = (
+            "id",
+            "name",
+            "alt_names",
+            "sort_name",
+            "volume",
+            "year_began",
+            "series_type",
+            "genres",
+        )
 
 
 class IssueListSeriesSerializer(serializers.ModelSerializer):

--- a/tests/comicsdb/test_api_issue.py
+++ b/tests/comicsdb/test_api_issue.py
@@ -139,6 +139,19 @@ def test_get_valid_single_arc(api_client_with_credentials, issue_with_arc):
     assert resp.status_code == status.HTTP_200_OK
 
 
+def test_detail_view_includes_series_alt_names(
+    api_client_with_credentials, issue_with_arc, fc_series
+):
+    fc_series.alt_names = ["Crisis on Infinite Worlds"]
+    fc_series.save()
+
+    resp = api_client_with_credentials.get(
+        reverse("api:issue-detail", kwargs={"pk": issue_with_arc.pk})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["series"]["alt_names"] == ["Crisis on Infinite Worlds"]
+
+
 def test_get_invalid_single_arc(api_client_with_credentials):
     resp = api_client_with_credentials.get(reverse("api:issue-detail", kwargs={"pk": "10"}))
     assert resp.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- Add `alt_names` to `IssueSeriesSerializer` so the issue detail endpoint's nested `series` object includes alternative series names
- Add a test verifying `alt_names` is returned on the issue detail endpoint
- Document the detail view's expanded `series` fields (`sort_name`, `series_type`, `genres`, `alt_names`) in api/README.md
