### PR TITLE
Fix 500 error on empty autocomplete selection in collection/pull/wish/reading list forms

### DIFF
--- a/pull_list/forms.py
+++ b/pull_list/forms.py
@@ -1,7 +1,7 @@
-from autocomplete import widgets
 from django import forms
 
 from comicsdb.autocomplete import SeriesAutocomplete
+from comicsdb.forms.widgets import SafeAutocompleteWidget
 from comicsdb.models.series import Series
 
 
@@ -9,7 +9,7 @@ class AddSeriesToPullListForm(forms.Form):
     series = forms.ModelChoiceField(
         queryset=Series.objects.select_related("series_type").all(),
         required=True,
-        widget=widgets.AutocompleteWidget(
+        widget=SafeAutocompleteWidget(
             ac_class=SeriesAutocomplete,
             attrs={
                 "placeholder": "Search for a series...",

--- a/reading_lists/forms.py
+++ b/reading_lists/forms.py
@@ -1,4 +1,3 @@
-from autocomplete import widgets
 from django import forms
 
 from comicsdb.autocomplete import ArcAutocomplete, IssueAutocomplete, SeriesAutocomplete
@@ -96,7 +95,7 @@ class AddIssueWithSearchForm(forms.Form):
     issues = forms.ModelMultipleChoiceField(
         queryset=Issue.objects.select_related("series", "series__series_type").all(),
         required=False,
-        widget=widgets.AutocompleteWidget(
+        widget=SafeAutocompleteWidget(
             ac_class=IssueAutocomplete,
             attrs={
                 "placeholder": "Search for issues...",
@@ -127,7 +126,7 @@ class AddIssuesFromSeriesForm(forms.Form):
     series = forms.ModelChoiceField(
         queryset=Series.objects.select_related("series_type").all(),
         required=True,
-        widget=widgets.AutocompleteWidget(
+        widget=SafeAutocompleteWidget(
             ac_class=SeriesAutocomplete,
             attrs={
                 "placeholder": "Search for a series...",
@@ -194,7 +193,7 @@ class AddIssuesFromArcForm(forms.Form):
     arc = forms.ModelChoiceField(
         queryset=Arc.objects.all(),
         required=True,
-        widget=widgets.AutocompleteWidget(
+        widget=SafeAutocompleteWidget(
             ac_class=ArcAutocomplete,
             attrs={
                 "placeholder": "Search for a story arc...",

--- a/user_collection/forms.py
+++ b/user_collection/forms.py
@@ -1,8 +1,7 @@
-from autocomplete import widgets
 from django import forms
 
 from comicsdb.autocomplete import IssueAutocomplete, SeriesAutocomplete
-from comicsdb.forms.widgets import BulmaMoneyWidget
+from comicsdb.forms.widgets import BulmaMoneyWidget, SafeAutocompleteWidget
 from comicsdb.models.series import Series
 from user_collection.models import CollectionItem
 
@@ -26,7 +25,7 @@ class CollectionItemForm(forms.ModelForm):
             "is_read",
         )
         widgets = {
-            "issue": widgets.AutocompleteWidget(
+            "issue": SafeAutocompleteWidget(
                 ac_class=IssueAutocomplete,
                 attrs={
                     "placeholder": "Search for an issue...",
@@ -122,7 +121,7 @@ class AddIssuesFromSeriesForm(forms.Form):
     series = forms.ModelChoiceField(
         queryset=Series.objects.select_related("series_type").all(),
         required=True,
-        widget=widgets.AutocompleteWidget(
+        widget=SafeAutocompleteWidget(
             ac_class=SeriesAutocomplete,
             attrs={
                 "placeholder": "Search for a series...",

--- a/wish_list/forms.py
+++ b/wish_list/forms.py
@@ -1,9 +1,8 @@
-from autocomplete import widgets
 from django import forms
 from djmoney.forms.fields import MoneyField
 
 from comicsdb.autocomplete import IssueAutocomplete
-from comicsdb.forms.widgets import BulmaMoneyWidget
+from comicsdb.forms.widgets import BulmaMoneyWidget, SafeAutocompleteWidget
 from wish_list.models import WishListItem
 
 
@@ -19,7 +18,7 @@ class WishListItemForm(forms.ModelForm):
             "notes",
         )
         widgets = {
-            "issue": widgets.AutocompleteWidget(
+            "issue": SafeAutocompleteWidget(
                 ac_class=IssueAutocomplete,
                 attrs={
                     "placeholder": "Search for an issue...",


### PR DESCRIPTION
## Summary
- `/collection/add/` (and similarly `pull_list`, `wish_list`, and `reading_lists` forms) threw a 500 error when submitted without selecting an autocomplete item and the form was redisplayed with validation errors.
- Root cause: these forms used the upstream `autocomplete` package's `AutocompleteWidget` directly. When re-rendering with an empty value (`''`), the widget only guards against `value is None`, so it passes `['']` into `queryset.filter(id__in=[''])`, which raises `ValueError: Field 'id' expected a number but got ''.` since `id` is an integer field.
- `comicsdb/forms/widgets.py` already has a `SafeAutocompleteWidget` subclass that fixes this exact issue by normalizing `''`/`[]` to `None`, but it wasn't applied consistently across the codebase. Swapped the remaining raw `AutocompleteWidget` usages over to it:
  - `user_collection/forms.py` — `CollectionItemForm.issue`, `AddIssuesFromSeriesForm.series`
  - `pull_list/forms.py` — `AddSeriesToPullListForm.series`
  - `wish_list/forms.py` — `WishListItemForm.issue`
  - `reading_lists/forms.py` — `AddIssueWithSearchForm.issues`, `AddIssuesFromSeriesForm.series`, `AddIssuesFromArcForm.arc`