### PR TITLE
Add auth-method adoption tracking and 429 throttle tracking

### DIFF
--- a/api/authentication.py
+++ b/api/authentication.py
@@ -1,0 +1,50 @@
+"""Tracks which authentication method API requests use.
+
+Part of the Basic Auth deprecation migration: lets us measure adoption of
+token-based auth over time before removing Basic Auth entirely.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from django.core.cache import cache
+from knox.auth import TokenAuthentication
+from rest_framework.authentication import BasicAuthentication, SessionAuthentication
+
+logger = logging.getLogger(__name__)
+
+# Counters are keyed per day, so this is just cleanup headroom, not a retention window.
+AUTH_METHOD_COUNTER_TTL = 60 * 60 * 24 * 35
+
+
+def _classify_authenticator(authenticator):
+    # isinstance, not class-name matching, so any future authenticator subclasses
+    # are still classified correctly.
+    if isinstance(authenticator, TokenAuthentication):
+        return "token"
+    if isinstance(authenticator, BasicAuthentication):
+        return "basic"
+    if isinstance(authenticator, SessionAuthentication):
+        return "session"
+    return "other"
+
+
+def record_auth_method_usage(request, user):
+    """Log and count which authenticator succeeded for this request."""
+    authenticator = request.successful_authenticator
+    if authenticator is None:
+        return
+
+    slug = _classify_authenticator(authenticator)
+
+    today = datetime.now(UTC).date().isoformat()
+    cache_key = f"authmethod:{slug}:{today}"
+    cache.add(cache_key, 0, timeout=AUTH_METHOD_COUNTER_TTL)
+    cache.incr(cache_key)
+
+    logger.info(
+        "API request authenticated via %s (user=%s)",
+        slug,
+        user.username,
+        extra={"username": user.username, "auth_method": slug},
+    )

--- a/api/client_health.py
+++ b/api/client_health.py
@@ -1,0 +1,44 @@
+"""Tracks API clients that don't back off after being rate-limited.
+
+A client that keeps retrying after a 429 instead of backing off puts
+unnecessary load on production. This logs and counts those events (per
+user/day where a user can be identified) so the offending client can be
+traced back to a specific account and contacted.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+# Counters are keyed per day, so this is cleanup headroom, not a retention window.
+CLIENT_HEALTH_COUNTER_TTL = 60 * 60 * 24 * 35
+
+
+def _today():
+    return datetime.now(UTC).date().isoformat()
+
+
+def _request_identity(request):
+    user = getattr(request, "user", None)
+    if user is not None and getattr(user, "is_authenticated", False):
+        return f"user:{user.username}"
+    return f"ip:{request.META.get('REMOTE_ADDR', 'unknown')}"
+
+
+def record_throttled_request(request, scope):
+    """Called whenever a throttle denies a request (a 429 is about to be returned)."""
+    identity = _request_identity(request)
+    cache_key = f"throttled:{scope}:{identity}:{_today()}"
+    cache.add(cache_key, 0, timeout=CLIENT_HEALTH_COUNTER_TTL)
+    count = cache.incr(cache_key)
+
+    logger.warning(
+        "Request throttled (%s limit) for %s (%d today)",
+        scope,
+        identity,
+        count,
+        extra={"identity": identity, "scope": scope, "count": count},
+    )

--- a/api/throttle.py
+++ b/api/throttle.py
@@ -2,6 +2,9 @@ import math
 
 from rest_framework.throttling import UserRateThrottle
 
+from api.authentication import record_auth_method_usage
+from api.client_health import record_throttled_request
+
 
 class RateLimitHeadersMixin:
     def allow_request(self, request, view):
@@ -19,6 +22,8 @@ class RateLimitHeadersMixin:
             django_request._throttle_headers[f"X-RateLimit-{scope}-Limit"] = str(self.num_requests)
             django_request._throttle_headers[f"X-RateLimit-{scope}-Remaining"] = str(remaining)
             django_request._throttle_headers[f"X-RateLimit-{scope}-Reset"] = str(reset_time)
+        if not result:
+            record_throttled_request(request, getattr(self, "scope", "default"))
         return result
 
 
@@ -35,4 +40,5 @@ class SustainedRateThrottle(RateLimitHeadersMixin, UserRateThrottle):
             supporter_limit = getattr(user, "supporter_daily_limit", None)
             if supporter_limit:
                 self.num_requests, self.duration = self.parse_rate(f"{supporter_limit}/day")
+            record_auth_method_usage(request, user)
         return super().allow_request(request, view)

--- a/metron/settings.py
+++ b/metron/settings.py
@@ -251,6 +251,12 @@ logging.config.dictConfig(
                 # Avoid double logging because of root logger
                 "propagate": False,
             },
+            "api": {
+                "level": LOGLEVEL,
+                "handlers": ["console"],
+                # Avoid double logging because of root logger
+                "propagate": False,
+            },
             # "django.db.backends": {
             #     "level": "DEBUG",
             #     "handlers": ["console"],

--- a/tests/api/test_auth_method_tracking.py
+++ b/tests/api/test_auth_method_tracking.py
@@ -1,0 +1,139 @@
+import base64
+import logging
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from django.core.cache.backends.locmem import LocMemCache
+from django.urls import reverse
+from knox.auth import TokenAuthentication
+from rest_framework import status
+from rest_framework.authentication import (
+    BaseAuthentication,
+    BasicAuthentication,
+    SessionAuthentication,
+)
+
+from api.authentication import record_auth_method_usage
+
+TODAY = datetime.now(UTC).date().isoformat()
+
+
+class DummyUser:
+    username = "dummy"
+
+
+class DummyRequest:
+    def __init__(self, authenticator=None):
+        self.successful_authenticator = authenticator
+
+
+class _UnrecognizedAuthenticator(BaseAuthentication):
+    """A real authenticator that isn't Basic/Session/Token, for the "other" case."""
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — isolated from the real (shared) cache backend, since these
+# counters are global-per-day and would otherwise collide with other tests
+# running concurrently under pytest-xdist.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def local_cache():
+    # LocMemCache's backing store is a process-wide dict keyed by location, so a
+    # fixed name would leak state between tests in the same xdist worker.
+    test_cache = LocMemCache(f"test-auth-method-tracking-{uuid.uuid4()}", {})
+    with patch("api.authentication.cache", test_cache):
+        yield test_cache
+
+
+def test_noop_when_no_successful_authenticator(local_cache):
+    record_auth_method_usage(DummyRequest(authenticator=None), DummyUser())
+    assert local_cache.get(f"authmethod:basic:{TODAY}") is None
+    assert local_cache.get(f"authmethod:other:{TODAY}") is None
+
+
+@pytest.mark.parametrize(
+    ("authenticator_cls", "slug"),
+    [
+        (BasicAuthentication, "basic"),
+        (SessionAuthentication, "session"),
+        (TokenAuthentication, "token"),
+        (_UnrecognizedAuthenticator, "other"),
+    ],
+)
+def test_increments_counter_for_authenticator(local_cache, authenticator_cls, slug):
+    record_auth_method_usage(DummyRequest(authenticator_cls()), DummyUser())
+    assert local_cache.get(f"authmethod:{slug}:{TODAY}") == 1
+
+
+def test_repeated_calls_increment_the_same_counter(local_cache):
+    request = DummyRequest(TokenAuthentication())
+    user = DummyUser()
+    record_auth_method_usage(request, user)
+    record_auth_method_usage(request, user)
+    record_auth_method_usage(request, user)
+    assert local_cache.get(f"authmethod:token:{TODAY}") == 3
+
+
+def test_logs_username_and_auth_method(local_cache, caplog):
+    caplog.set_level(logging.INFO, logger="api.authentication")
+    record_auth_method_usage(DummyRequest(TokenAuthentication()), DummyUser())
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.username == "dummy"
+    assert record.auth_method == "token"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — verify real requests trigger tracking with the right
+# authenticator, without touching the shared cache (mocked out for the same
+# reason as above).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_basic_auth_request_tracked_as_basic(create_user, api_client, test_password):
+    user = create_user()
+    credentials = base64.b64encode(f"{user.username}:{test_password}".encode()).decode()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Basic {credentials}")
+
+    with patch("api.throttle.record_auth_method_usage") as mock_record:
+        resp = api_client.get(reverse("api:arc-list"))
+
+    assert resp.status_code == status.HTTP_200_OK
+    mock_record.assert_called_once()
+    called_request, called_user = mock_record.call_args.args
+    assert called_user == user
+    assert isinstance(called_request.successful_authenticator, BasicAuthentication)
+
+
+@pytest.mark.django_db
+def test_token_auth_request_tracked_as_token(api_client_with_token_credentials):
+    api_client, user = api_client_with_token_credentials
+
+    with patch("api.throttle.record_auth_method_usage") as mock_record:
+        resp = api_client.get(reverse("api:arc-list"))
+
+    assert resp.status_code == status.HTTP_200_OK
+    mock_record.assert_called_once()
+    called_request, called_user = mock_record.call_args.args
+    assert called_user == user
+    assert called_request.successful_authenticator.__class__.__name__ == "TokenAuthentication"
+
+
+@pytest.mark.django_db
+def test_session_auth_request_tracked_as_session(create_user, api_client, test_password):
+    user = create_user()
+    api_client.login(username=user.username, password=test_password)
+
+    with patch("api.throttle.record_auth_method_usage") as mock_record:
+        resp = api_client.get(reverse("api:arc-list"))
+
+    assert resp.status_code == status.HTTP_200_OK
+    mock_record.assert_called_once()
+    called_request, called_user = mock_record.call_args.args
+    assert called_user == user
+    assert called_request.successful_authenticator.__class__.__name__ == "SessionAuthentication"

--- a/tests/api/test_client_health.py
+++ b/tests/api/test_client_health.py
@@ -1,0 +1,92 @@
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from django.core.cache import cache
+from django.test import RequestFactory
+from django.urls import reverse
+from rest_framework import status
+
+from api.client_health import record_throttled_request
+
+TODAY = datetime.now(UTC).date().isoformat()
+
+
+class DummyUser:
+    def __init__(self, username, is_authenticated=True):
+        self.username = username
+        self.is_authenticated = is_authenticated
+
+
+def _unique():
+    return uuid.uuid4().hex
+
+
+# ---------------------------------------------------------------------------
+# Unit tests. Cache keys are scoped by a unique identity per call, so these
+# are safe against the real (shared) cache backend without needing isolation.
+# ---------------------------------------------------------------------------
+
+
+def test_record_throttled_request_counts_authenticated_user():
+    username = _unique()
+    request = RequestFactory().get("/")
+    request.user = DummyUser(username)
+
+    record_throttled_request(request, "burst")
+
+    assert cache.get(f"throttled:burst:user:{username}:{TODAY}") == 1
+
+
+def test_record_throttled_request_counts_anonymous_by_ip():
+    # Unique-per-test IP (rather than a fixed address) so repeated local runs
+    # against the same day don't accumulate a stale count from a prior run.
+    ip = f"203.0.113.{uuid.uuid4().int % 255}"
+    cache_key = f"throttled:sustained:ip:{ip}:{TODAY}"
+    cache.delete(cache_key)
+    request = RequestFactory().get("/", REMOTE_ADDR=ip)
+    request.user = DummyUser("irrelevant", is_authenticated=False)
+
+    record_throttled_request(request, "sustained")
+
+    assert cache.get(cache_key) == 1
+
+
+def test_record_throttled_request_increments_on_repeat():
+    username = _unique()
+    request = RequestFactory().get("/")
+    request.user = DummyUser(username)
+
+    record_throttled_request(request, "burst")
+    record_throttled_request(request, "burst")
+
+    assert cache.get(f"throttled:burst:user:{username}:{TODAY}") == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration test — verify a real throttled request is tracked.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_exceeding_burst_limit_returns_429_and_is_tracked(create_user, api_client):
+    user = create_user()
+    api_client.force_authenticate(user=user)
+    # DRF's own burst-throttle history is Redis-backed and keyed by user pk, which
+    # test-db recreation recycles across runs — clear any stale leftover history
+    # for this pk so the test starts from a known-clean state.
+    burst_key = f"throttle_burst_{user.pk}"
+    cache.delete(burst_key)
+
+    try:
+        for _ in range(20):
+            resp = api_client.get(reverse("api:arc-list"))
+            assert resp.status_code == status.HTTP_200_OK
+        throttled_resp = api_client.get(reverse("api:arc-list"))
+
+        assert throttled_resp.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert cache.get(f"throttled:burst:user:{user.username}:{TODAY}") == 1
+    finally:
+        # Don't leave this pk's burst history exhausted for whatever test/run
+        # recycles it next.
+        cache.delete(burst_key)


### PR DESCRIPTION
## Summary

Closes #577. Part of #575 (Token-Based API Authentication Phase 1).

Adds two pieces of request-level observability, driven by the actual production-health priority: identifying clients that don't back off after being rate-limited.

### Auth-method adoption tracking (`api/authentication.py`)
- Classifies `request.successful_authenticator` (Basic/Session/Token/other) via `isinstance`
- Logs `INFO`: `API request authenticated via <method> (user=<username>)`
- Redis counter: `authmethod:<method>:<date>`

### 429 (throttled request) tracking (`api/client_health.py`) — the priority
- Fires whenever a throttle (burst or sustained) denies a request
- Logs `WARNING`: `Request throttled (<scope> limit) for <identity> (<N> today)`, where identity is `user:<username>` or `ip:<addr>`
- Redis counter: `throttled:<scope>:<identity>:<date>`
- Lets us identify repeat offenders directly from logs/counters instead of guessing from load

Both wired into `api/throttle.py`'s existing throttle classes; a new `"api"` logger entry was added to `metron/settings.py` so these actually surface in production (`journalctl -u metron-web.service`).
