### PR TITLE
Refine throttle-notification trigger and docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -967,24 +967,25 @@ done
 
 ### Contacting repeat offenders
 
-`python manage.py notify_throttled_clients` scans the `throttled:*` counters above for
-accounts hitting rate limits without backing off (3+ distinct days throttled in the last 7,
-or 50+ in a single day, by default - see `--help` for all thresholds) and reports candidates
+`notify_throttled_clients` scans the `throttled:*` counters above for
+accounts hitting rate limits without backing off (50+ throttled requests on 3+ separate days
+within the last 7, or 100+ in a single day on its own, by default - see `--help` for all
+thresholds) and reports candidates
 (stdout + a Pushover ping to `PUSHOVER_USER_KEY`, which can be a comma-separated list to
 reach multiple admins). It never sends anything on its own:
 
 ```bash
 # Report only - no emails sent, no state changed
-python manage.py notify_throttled_clients
+podman exec metron-web python manage.py notify_throttled_clients
 
 # Actually email eligible candidates (email_confirmed accounts only) and record a
 # ThrottleNotice so the same account isn't re-emailed within --cooldown-days (default 7)
-python manage.py notify_throttled_clients --send
+podman exec metron-web python manage.py notify_throttled_clients --send
 ```
 
 Sent notices are visible (read-only) in Django admin under API > Throttle notices. There's
 no timer wired up for this yet - run it by hand, or add a systemd timer in report-only mode
-the same way as `metron-opencollective-sync.timer` below if periodic review is wanted.
+the same way as `metron-opencollective-sync.timer` above if periodic review is wanted.
 
 ---
 

--- a/api/client_health.py
+++ b/api/client_health.py
@@ -62,13 +62,22 @@ class RepeatOffender:
 
 
 def find_repeat_offenders(
-    lookback_days: int = 7, min_days: int = 3, single_day_threshold: int = 50
+    lookback_days: int = 7,
+    min_days: int = 3,
+    single_day_threshold: int = 50,
+    extreme_day_threshold: int = 100,
 ) -> list[RepeatOffender]:
     """Scan the throttled-request counters for accounts that keep getting
-    rate-limited without backing off: throttled on `min_days`+ distinct UTC days,
-    or with any single day's count at or above `single_day_threshold`, within the
-    last `lookback_days` days. IP-only identities (unauthenticated requests) are
-    skipped - there's no account to contact.
+    rate-limited without backing off. Flags an account if either is true, within
+    the last `lookback_days`:
+
+    - it has at least `min_days` distinct UTC days whose daily count is at or
+      above `single_day_threshold` (sustained high-volume throttling), or
+    - any single day's count is at or above `extreme_day_threshold` on its own
+      (a client hammering the API with no backoff at all).
+
+    IP-only identities (unauthenticated requests) are skipped - there's no
+    account to contact.
 
     Django's cache framework has no key-scanning API, so this drops to the
     underlying redis-py client (the same one the cache backend itself uses) to
@@ -103,15 +112,16 @@ def find_repeat_offenders(
 
     offenders = []
     for username, daily_counts in daily_counts_by_user.items():
-        days_throttled = len(daily_counts)
+        bad_days = [count for count in daily_counts.values() if count >= single_day_threshold]
         worst_day_count = max(daily_counts.values())
-        if days_throttled >= min_days or worst_day_count >= single_day_threshold:
-            offenders.append(
-                RepeatOffender(
-                    username=username,
-                    days_throttled=days_throttled,
-                    total_count=sum(daily_counts.values()),
-                    worst_day_count=worst_day_count,
-                )
+        if len(bad_days) < min_days and worst_day_count < extreme_day_threshold:
+            continue
+        offenders.append(
+            RepeatOffender(
+                username=username,
+                days_throttled=len(bad_days),
+                total_count=sum(daily_counts.values()),
+                worst_day_count=worst_day_count,
             )
+        )
     return offenders

--- a/api/management/commands/notify_throttled_clients.py
+++ b/api/management/commands/notify_throttled_clients.py
@@ -13,6 +13,7 @@ from users.utils import send_pushover
 DEFAULT_LOOKBACK_DAYS = 7
 DEFAULT_MIN_DAYS = 3
 DEFAULT_SINGLE_DAY_THRESHOLD = 50
+DEFAULT_EXTREME_DAY_THRESHOLD = 100
 DEFAULT_COOLDOWN_DAYS = 7
 
 
@@ -33,13 +34,22 @@ class Command(BaseCommand):
             "--min-days",
             type=int,
             default=DEFAULT_MIN_DAYS,
-            help="Flag accounts throttled on at least this many distinct days",
+            help=(
+                "Flag accounts with at least this many days whose throttled count "
+                "reaches --single-day-threshold"
+            ),
         )
         parser.add_argument(
             "--single-day-threshold",
             type=int,
             default=DEFAULT_SINGLE_DAY_THRESHOLD,
-            help="Flag accounts with any single day's throttled count at or above this",
+            help="A day only counts toward --min-days if its throttled count is at least this",
+        )
+        parser.add_argument(
+            "--extreme-day-threshold",
+            type=int,
+            default=DEFAULT_EXTREME_DAY_THRESHOLD,
+            help="Flag an account outright if any single day's throttled count reaches this",
         )
         parser.add_argument(
             "--cooldown-days",
@@ -61,6 +71,7 @@ class Command(BaseCommand):
             lookback_days=options["lookback_days"],
             min_days=options["min_days"],
             single_day_threshold=options["single_day_threshold"],
+            extreme_day_threshold=options["extreme_day_threshold"],
         )
 
         candidates = []

--- a/api/templates/api/throttle_notice_email.html
+++ b/api/templates/api/throttle_notice_email.html
@@ -85,7 +85,7 @@
                                               font-family: Arial, Helvetica, sans-serif">
                                         For details on our current rate limits and how to implement a backoff
                                         strategy, see our
-                                        <a href="https://github.com/Metron-Project/metron/blob/master/api/README.md#rate-limiting"
+                                        <a href="https://metron.cloud/wiki/api/handling-rate-limits/"
                                            style="color: #3273dc;">Rate Limiting documentation</a>.
                                     </p>
                                     <!-- Warning Box -->

--- a/api/templates/api/throttle_notice_email.txt
+++ b/api/templates/api/throttle_notice_email.txt
@@ -13,7 +13,7 @@ before retrying, rather than retrying immediately.
 For details on our current rate limits and how to implement a backoff strategy,
 see:
 
-https://github.com/Metron-Project/metron/blob/master/api/README.md#rate-limiting
+https://metron.cloud/wiki/api/handling-rate-limits/
 
 IMPORTANT: If this behavior continues, we may revoke API access for this account
 to protect the site for other users.

--- a/tests/api/test_client_health.py
+++ b/tests/api/test_client_health.py
@@ -107,40 +107,71 @@ def test_exceeding_burst_limit_returns_429_and_is_tracked(create_user, api_clien
 # ---------------------------------------------------------------------------
 
 
-def test_finds_user_throttled_on_min_days():
+def test_finds_user_with_min_days_at_or_above_threshold():
     username = _unique()
     for days_ago in (0, 1, 2):
-        _set_count("burst", f"user:{username}", days_ago, 5)
-
-    offenders = find_repeat_offenders(lookback_days=7, min_days=3, single_day_threshold=1000)
-
-    matches = [o for o in offenders if o.username == username]
-    assert len(matches) == 1
-    assert matches[0].days_throttled == 3
-    assert matches[0].total_count == 15
-    assert matches[0].worst_day_count == 5
-
-
-def test_ignores_user_below_both_thresholds():
-    username = _unique()
-    for days_ago in (0, 1):
-        _set_count("burst", f"user:{username}", days_ago, 2)
-
-    offenders = find_repeat_offenders(lookback_days=7, min_days=3, single_day_threshold=1000)
-
-    assert all(o.username != username for o in offenders)
-
-
-def test_single_day_threshold_flags_even_one_day():
-    username = _unique()
-    _set_count("sustained", f"user:{username}", 0, 100)
+        _set_count("burst", f"user:{username}", days_ago, 60)
 
     offenders = find_repeat_offenders(lookback_days=7, min_days=3, single_day_threshold=50)
 
     matches = [o for o in offenders if o.username == username]
     assert len(matches) == 1
+    assert matches[0].days_throttled == 3
+    assert matches[0].total_count == 180
+    assert matches[0].worst_day_count == 60
+
+
+def test_ignores_user_with_too_few_days_at_threshold():
+    username = _unique()
+    # Only 2 of the 3 required days reach the threshold.
+    for days_ago in (0, 1):
+        _set_count("burst", f"user:{username}", days_ago, 60)
+    _set_count("burst", f"user:{username}", 2, 5)
+
+    offenders = find_repeat_offenders(lookback_days=7, min_days=3, single_day_threshold=50)
+
+    assert all(o.username != username for o in offenders)
+
+
+def test_ignores_user_with_many_low_volume_days():
+    # A user throttled on min_days+ days, but never at the per-day threshold,
+    # shouldn't be flagged - low-volume repeated throttling isn't worth an email.
+    username = _unique()
+    for days_ago in (0, 1, 2):
+        _set_count("burst", f"user:{username}", days_ago, 3)
+
+    offenders = find_repeat_offenders(lookback_days=7, min_days=3, single_day_threshold=50)
+
+    assert all(o.username != username for o in offenders)
+
+
+def test_single_bad_day_below_extreme_threshold_does_not_trigger_alone():
+    # A single day above single_day_threshold but below extreme_day_threshold
+    # shouldn't flag an account on its own - it takes min_days separate days.
+    username = _unique()
+    _set_count("sustained", f"user:{username}", 0, 90)
+
+    offenders = find_repeat_offenders(
+        lookback_days=7, min_days=3, single_day_threshold=50, extreme_day_threshold=100
+    )
+
+    assert all(o.username != username for o in offenders)
+
+
+def test_extreme_single_day_triggers_alone():
+    # A single day at or above extreme_day_threshold flags the account outright,
+    # even though it's only one day (well short of min_days).
+    username = _unique()
+    _set_count("sustained", f"user:{username}", 0, 150)
+
+    offenders = find_repeat_offenders(
+        lookback_days=7, min_days=3, single_day_threshold=50, extreme_day_threshold=100
+    )
+
+    matches = [o for o in offenders if o.username == username]
+    assert len(matches) == 1
     assert matches[0].days_throttled == 1
-    assert matches[0].worst_day_count == 100
+    assert matches[0].worst_day_count == 150
 
 
 def test_ignores_dates_outside_lookback_window():


### PR DESCRIPTION
## Summary

Follow-up to the automated outreach feature for repeatedly throttled API clients (#579). Tightens the trigger criteria after reviewing real candidate output, and fixes a couple of loose ends in the docs/templates.

- **Fix false-positive trigger:** previously any day with a nonzero throttled count counted toward `--min-days`, so an account with just a few low-volume days (e.g. 3 requests/day for 3 days) could get flagged. A day now only counts if its own count reaches `--single-day-threshold` (default 50).
- **Add `--extreme-day-threshold`** (default 100): a single day at or above this flags an account outright, even without `--min-days` repeated bad days - for a client hammering the API with zero backoff.
- Point the throttle-notice email at the wiki (`https://metron.cloud/wiki/api/handling-rate-limits/`) instead of the `api/README.md` rate-limiting section.
- Update `DEPLOYMENT.md`'s example commands to run through `podman exec metron-web`, matching every other command in that doc.

