### PR TITLE
Add automated outreach for repeatedly throttled API clients

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -987,6 +987,32 @@ Sent notices are visible (read-only) in Django admin under API > Throttle notice
 no timer wired up for this yet - run it by hand, or add a systemd timer in report-only mode
 the same way as `metron-opencollective-sync.timer` above if periodic review is wanted.
 
+### Escalating to enforcement
+
+Add `--enforce` to escalate instead of sending another plain warning once an account
+already has `--enforce-after` prior notices (default 2, so its 3rd notice escalates, its
+4th escalates again, and so on for as long as it keeps qualifying):
+
+- If the account has any API tokens (`ApiToken`/knox), they're all revoked.
+- Otherwise (no tokens left to revoke), the account is disabled (`is_active=False`) -
+  this blocks Basic, Session, and Token auth all at once, so a disabled account drops
+  out of future candidate lists on its own.
+
+Like `--send`, `--enforce` gates the actual mutation - pass `--enforce` alone (without
+`--send`) to preview what it *would* do for each candidate (revoke tokens vs. disable)
+without changing anything:
+
+```bash
+# Preview who would be enforced vs. just warned, without sending anything
+podman exec metron-web python manage.py notify_throttled_clients --enforce
+
+# Actually warn first-and-second-time offenders, and enforce on the 3rd+
+podman exec metron-web python manage.py notify_throttled_clients --send --enforce
+```
+
+There's no self-service or automatic re-enable - a disabled account has to be manually
+flipped back to `is_active=True` in Django admin after review.
+
 ---
 
 ## Useful commands

--- a/api/management/commands/notify_throttled_clients.py
+++ b/api/management/commands/notify_throttled_clients.py
@@ -15,12 +15,16 @@ DEFAULT_MIN_DAYS = 3
 DEFAULT_SINGLE_DAY_THRESHOLD = 50
 DEFAULT_EXTREME_DAY_THRESHOLD = 100
 DEFAULT_COOLDOWN_DAYS = 7
+DEFAULT_ENFORCE_AFTER = 2
 
 
 class Command(BaseCommand):
     help = (
         "Find accounts whose API client keeps getting rate-limited without backing off, "
-        "and (with --send) email them. Without --send, only reports candidates."
+        "and (with --send) email them. Without --send, only reports candidates. With "
+        "--enforce, an account that's already had --enforce-after prior notices gets its "
+        "API tokens revoked (or, if it has none, the account disabled) instead of another "
+        "plain warning - add --send to actually do it, or leave it off to preview."
     )
 
     def add_arguments(self, parser) -> None:
@@ -62,9 +66,28 @@ class Command(BaseCommand):
             action="store_true",
             help="Actually send emails and record ThrottleNotice rows (default: report only)",
         )
+        parser.add_argument(
+            "--enforce",
+            action="store_true",
+            help=(
+                "Escalate instead of warning again once an account already has "
+                "--enforce-after prior notices. Combine with --send to actually revoke "
+                "tokens/disable the account; without --send, only previews the action."
+            ),
+        )
+        parser.add_argument(
+            "--enforce-after",
+            type=int,
+            default=DEFAULT_ENFORCE_AFTER,
+            help=(
+                "Number of prior notices an account must already have before --enforce "
+                "escalates its next one (default 2, so the 3rd notice escalates)"
+            ),
+        )
 
     def handle(self, *args, **options) -> None:
         send = options["send"]
+        enforce = options["enforce"]
         cooldown_cutoff = timezone.now() - timedelta(days=options["cooldown_days"])
 
         offenders = find_repeat_offenders(
@@ -87,7 +110,10 @@ class Command(BaseCommand):
                 continue
             if ThrottleNotice.objects.filter(user=user, sent_at__gte=cooldown_cutoff).exists():
                 continue
-            candidates.append((user, offender))
+
+            prior_notices = ThrottleNotice.objects.filter(user=user).count()
+            will_enforce = enforce and prior_notices >= options["enforce_after"]
+            candidates.append((user, offender, will_enforce))
 
         self._print_summary(candidates, send)
 
@@ -95,16 +121,23 @@ class Command(BaseCommand):
             send_pushover(self._pushover_message(candidates, send))
 
         if send:
-            for user, offender in candidates:
-                self._notify(user, offender)
+            for user, offender, will_enforce in candidates:
+                if will_enforce:
+                    self._enforce_and_notify(user, offender)
+                else:
+                    self._notify(user, offender)
 
     def _print_summary(self, candidates, send: bool) -> None:
         if not candidates:
             self.stdout.write("No candidates found.")
             return
 
-        verb = "Emailing" if send else "Would email"
-        for user, offender in candidates:
+        for user, offender, will_enforce in candidates:
+            if will_enforce:
+                action = self._predict_enforcement_action(user)
+                verb = f"Enforcing ({action})" if send else f"Would enforce ({action})"
+            else:
+                verb = "Emailing" if send else "Would email"
             self.stdout.write(
                 f"{verb} {user.username} <{user.email}>: throttled on "
                 f"{offender.days_throttled} day(s), {offender.total_count} total, "
@@ -118,9 +151,13 @@ class Command(BaseCommand):
             )
 
     @staticmethod
+    def _predict_enforcement_action(user: CustomUser) -> str:
+        return "revoke tokens" if user.auth_token_set.exists() else "disable account"
+
+    @staticmethod
     def _pushover_message(candidates, send: bool) -> str:
         verb = "Emailed" if send else "Found"
-        names = ", ".join(user.username for user, _ in candidates)
+        names = ", ".join(user.username for user, _, _ in candidates)
         return f"{verb} {len(candidates)} throttled API client(s) on Metron: {names}"
 
     @staticmethod
@@ -130,6 +167,37 @@ class Command(BaseCommand):
         text_message = render_to_string("api/throttle_notice_email.txt", context)
         email = EmailMultiAlternatives(
             subject="Your Metron API client is being rate-limited",
+            body=text_message,
+            to=[user.email],
+        )
+        email.attach_alternative(html_message, "text/html")
+        email.send()
+
+        ThrottleNotice.objects.create(
+            user=user,
+            days_throttled=offender.days_throttled,
+            total_count=offender.total_count,
+            worst_day_count=offender.worst_day_count,
+        )
+
+    @staticmethod
+    def _enforce_and_notify(user: CustomUser, offender) -> None:
+        # Revoke tokens if the account has any - that alone stops a token-based
+        # client. Only disable the account outright once there's nothing left to
+        # revoke, since disabling also blocks Basic/Session auth for this user.
+        if user.auth_token_set.exists():
+            user.auth_token_set.all().delete()
+            account_disabled = False
+        else:
+            user.is_active = False
+            user.save(update_fields=["is_active"])
+            account_disabled = True
+
+        context = {"user": user, "account_disabled": account_disabled}
+        html_message = render_to_string("api/throttle_enforcement_email.html", context)
+        text_message = render_to_string("api/throttle_enforcement_email.txt", context)
+        email = EmailMultiAlternatives(
+            subject="Your Metron API access has been restricted",
             body=text_message,
             to=[user.email],
         )

--- a/api/management/commands/notify_throttled_clients.py
+++ b/api/management/commands/notify_throttled_clients.py
@@ -162,7 +162,12 @@ class Command(BaseCommand):
 
     @staticmethod
     def _notify(user: CustomUser, offender) -> None:
-        context = {"user": user}
+        context = {
+            "user": user,
+            "days_throttled": offender.days_throttled,
+            "total_count": offender.total_count,
+            "worst_day_count": offender.worst_day_count,
+        }
         html_message = render_to_string("api/throttle_notice_email.html", context)
         text_message = render_to_string("api/throttle_notice_email.txt", context)
         email = EmailMultiAlternatives(
@@ -193,7 +198,13 @@ class Command(BaseCommand):
             user.save(update_fields=["is_active"])
             account_disabled = True
 
-        context = {"user": user, "account_disabled": account_disabled}
+        context = {
+            "user": user,
+            "account_disabled": account_disabled,
+            "days_throttled": offender.days_throttled,
+            "total_count": offender.total_count,
+            "worst_day_count": offender.worst_day_count,
+        }
         html_message = render_to_string("api/throttle_enforcement_email.html", context)
         text_message = render_to_string("api/throttle_enforcement_email.txt", context)
         email = EmailMultiAlternatives(

--- a/api/templates/api/throttle_enforcement_email.html
+++ b/api/templates/api/throttle_enforcement_email.html
@@ -55,6 +55,28 @@
                                         hitting our rate limits without backing off. Since that behavior has
                                         continued, we've had to take action on this account:
                                     </p>
+                                    <!-- Stats Box -->
+                                    <table border="0"
+                                           cellpadding="0"
+                                           cellspacing="0"
+                                           width="100%"
+                                           style="margin: 0 0 20px 0;
+                                                  background-color: #f5f5f5;
+                                                  border-left: 4px solid #363636">
+                                        <tr>
+                                            <td style="padding: 15px 20px;">
+                                                <p style="margin: 0;
+                                                          font-size: 14px;
+                                                          color: #4a4a4a;
+                                                          font-family: Arial, Helvetica, sans-serif">
+                                                    Most recently, your client received
+                                                    <strong>{{ total_count }} rate-limited (429) response{{ total_count|pluralize }}</strong>
+                                                    across <strong>{{ days_throttled }} day{{ days_throttled|pluralize }}</strong>,
+                                                    including <strong>{{ worst_day_count }}</strong> in a single day.
+                                                </p>
+                                            </td>
+                                        </tr>
+                                    </table>
                                     <!-- Action Box -->
                                     <table border="0"
                                            cellpadding="0"

--- a/api/templates/api/throttle_enforcement_email.html
+++ b/api/templates/api/throttle_enforcement_email.html
@@ -1,0 +1,147 @@
+{% autoescape off %}
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <title>Your Metron API access has been restricted</title>
+        </head>
+        <body style="margin: 0;
+                     padding: 0;
+                     font-family: Arial, Helvetica, sans-serif;
+                     line-height: 1.6;
+                     color: #363636;
+                     background-color: #f5f5f5">
+            <!-- Wrapper table -->
+            <table border="0"
+                   cellpadding="0"
+                   cellspacing="0"
+                   width="100%"
+                   style="background-color: #f5f5f5">
+                <tr>
+                    <td align="center" style="padding: 20px 10px;">
+                        <!-- Email container -->
+                        <table border="0"
+                               cellpadding="0"
+                               cellspacing="0"
+                               width="600"
+                               style="max-width: 600px;
+                                      background-color: #ffffff">
+                            <!-- Header -->
+                            <tr>
+                                <td align="center" style="background-color: #3273dc; padding: 40px 20px;">
+                                    <h1 style="margin: 0;
+                                               color: #ffffff;
+                                               font-size: 32px;
+                                               font-weight: bold;
+                                               font-family: Arial, Helvetica, sans-serif">Metron</h1>
+                                </td>
+                            </tr>
+                            <!-- Main Content -->
+                            <tr>
+                                <td style="padding: 40px 30px;">
+                                    <h2 style="margin: 0 0 20px 0;
+                                               font-size: 24px;
+                                               color: #363636;
+                                               font-weight: 600;
+                                               font-family: Arial, Helvetica, sans-serif">
+                                        Hi {{ user.username }},
+                                    </h2>
+                                    <p style="margin: 0 0 20px 0;
+                                              font-size: 16px;
+                                              color: #4a4a4a;
+                                              font-family: Arial, Helvetica, sans-serif">
+                                        We previously warned you that your Metron API client was repeatedly
+                                        hitting our rate limits without backing off. Since that behavior has
+                                        continued, we've had to take action on this account:
+                                    </p>
+                                    <!-- Action Box -->
+                                    <table border="0"
+                                           cellpadding="0"
+                                           cellspacing="0"
+                                           width="100%"
+                                           style="margin: 0 0 30px 0;
+                                                  background-color: #feecf0;
+                                                  border-left: 4px solid #ff3860">
+                                        <tr>
+                                            <td style="padding: 20px;">
+                                                <p style="margin: 0;
+                                                          font-size: 14px;
+                                                          color: #4a4a4a;
+                                                          font-family: Arial, Helvetica, sans-serif">
+                                                    {% if account_disabled %}
+                                                        <strong>This account has been disabled.</strong> You won't
+                                                        be able to log in or use the API until an administrator
+                                                        reinstates it.
+                                                    {% else %}
+                                                        <strong>All API tokens for this account have been
+                                                        revoked.</strong> You'll need to generate a new token before
+                                                        you can use the API again.
+                                                    {% endif %}
+                                                </p>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <p style="margin: 0 0 30px 0;
+                                              font-size: 16px;
+                                              color: #4a4a4a;
+                                              font-family: Arial, Helvetica, sans-serif">
+                                        Before using the API again, please make sure your client respects the
+                                        <code>X-RateLimit-*</code> response headers and backs off after a 429
+                                        response instead of retrying immediately. For details on our rate limits
+                                        and how to implement a backoff strategy, see our
+                                        <a href="https://metron.cloud/wiki/api/handling-rate-limits/"
+                                           style="color: #3273dc;">Rate Limiting documentation</a>.
+                                    </p>
+                                    <p style="margin: 0;
+                                              font-size: 16px;
+                                              color: #4a4a4a;
+                                              font-family: Arial, Helvetica, sans-serif">
+                                        If you have any questions, or believe this was done in error, please reply
+                                        to this email so we can review it.
+                                    </p>
+                                </td>
+                            </tr>
+                            <!-- Footer -->
+                            <tr>
+                                <td style="background-color: #363636; padding: 30px; text-align: center;">
+                                    <p style="margin: 0 0 10px 0;
+                                              font-size: 14px;
+                                              color: #ffffff;
+                                              font-family: Arial, Helvetica, sans-serif">
+                                        <strong>Metron Comic Book Database</strong>
+                                    </p>
+                                    <p style="margin: 0 0 15px 0;
+                                              font-size: 14px;
+                                              color: #b5b5b5;
+                                              font-family: Arial, Helvetica, sans-serif">
+                                        A community-driven project for comic book enthusiasts
+                                    </p>
+                                    <p style="margin: 0 0 10px 0;
+                                              font-size: 14px;
+                                              font-family: Arial, Helvetica, sans-serif">
+                                        <a href="https://metron.cloud"
+                                           style="color: #3273dc;
+                                                  text-decoration: none">Visit Website</a> &#8226;
+                                        <a href="https://github.com/Metron-Project/metron"
+                                           style="color: #3273dc;
+                                                  text-decoration: none">GitHub</a> &#8226;
+                                        <a href="mailto:admin@metron.cloud"
+                                           style="color: #3273dc;
+                                                  text-decoration: none">Contact Us</a>
+                                    </p>
+                                    <p style="margin: 15px 0 0 0;
+                                              font-size: 12px;
+                                              color: #7a7a7a;
+                                              font-family: Arial, Helvetica, sans-serif">
+                                        &copy; {% now "Y" %} Metron Project. All rights reserved.
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </body>
+    </html>
+{% endautoescape %}

--- a/api/templates/api/throttle_enforcement_email.txt
+++ b/api/templates/api/throttle_enforcement_email.txt
@@ -4,6 +4,10 @@ We previously warned you that your Metron API client was repeatedly hitting our
 rate limits without backing off. Since that behavior has continued, we've had
 to take action on this account:
 
+Most recently, your client received {{ total_count }} rate-limited (429) response{{ total_count|pluralize }}
+across {{ days_throttled }} day{{ days_throttled|pluralize }}, including {{ worst_day_count }}
+in a single day.
+
 {% if account_disabled %}This account has been disabled. You won't be able to log in or use the API
 until an administrator reinstates it.{% else %}All API tokens for this account have been revoked. You'll need to generate a
 new token before you can use the API again.{% endif %}

--- a/api/templates/api/throttle_enforcement_email.txt
+++ b/api/templates/api/throttle_enforcement_email.txt
@@ -1,0 +1,30 @@
+{% autoescape off %}Hi {{ user.username }},
+
+We previously warned you that your Metron API client was repeatedly hitting our
+rate limits without backing off. Since that behavior has continued, we've had
+to take action on this account:
+
+{% if account_disabled %}This account has been disabled. You won't be able to log in or use the API
+until an administrator reinstates it.{% else %}All API tokens for this account have been revoked. You'll need to generate a
+new token before you can use the API again.{% endif %}
+
+Before using the API again, please make sure your client respects the
+X-RateLimit-* response headers and backs off after a 429 response instead of
+retrying immediately. For details on our rate limits and how to implement a
+backoff strategy, see:
+
+https://metron.cloud/wiki/api/handling-rate-limits/
+
+If you have any questions, or believe this was done in error, please reply to
+this email so we can review it.
+
+---
+Metron Comic Book Database
+A community-driven project for comic book enthusiasts
+
+Website: https://metron.cloud
+GitHub: https://github.com/Metron-Project/metron
+Contact: admin@metron.cloud
+
+(c) {% now "Y" %} Metron Project. All rights reserved.
+{% endautoescape %}

--- a/api/templates/api/throttle_notice_email.html
+++ b/api/templates/api/throttle_notice_email.html
@@ -56,6 +56,28 @@
                                         immediately after a 429 response instead of backing off, it adds
                                         unnecessary load to the site for everyone.
                                     </p>
+                                    <!-- Stats Box -->
+                                    <table border="0"
+                                           cellpadding="0"
+                                           cellspacing="0"
+                                           width="100%"
+                                           style="margin: 0 0 20px 0;
+                                                  background-color: #f5f5f5;
+                                                  border-left: 4px solid #363636">
+                                        <tr>
+                                            <td style="padding: 15px 20px;">
+                                                <p style="margin: 0;
+                                                          font-size: 14px;
+                                                          color: #4a4a4a;
+                                                          font-family: Arial, Helvetica, sans-serif">
+                                                    Your client received
+                                                    <strong>{{ total_count }} rate-limited (429) response{{ total_count|pluralize }}</strong>
+                                                    across <strong>{{ days_throttled }} day{{ days_throttled|pluralize }}</strong>,
+                                                    including <strong>{{ worst_day_count }}</strong> in a single day.
+                                                </p>
+                                            </td>
+                                        </tr>
+                                    </table>
                                     <!-- Info Box -->
                                     <table border="0"
                                            cellpadding="0"

--- a/api/templates/api/throttle_notice_email.txt
+++ b/api/templates/api/throttle_notice_email.txt
@@ -5,6 +5,10 @@ the past several days. When a client keeps retrying immediately after a 429
 response instead of backing off, it adds unnecessary load to the site for
 everyone.
 
+Your client received {{ total_count }} rate-limited (429) response{{ total_count|pluralize }}
+across {{ days_throttled }} day{{ days_throttled|pluralize }}, including {{ worst_day_count }}
+in a single day.
+
 Every API response includes X-RateLimit-* headers showing your current limit,
 remaining requests, and when the window resets. A 429 response also means you've
 exceeded that limit for the current window - the fix is to slow down and wait

--- a/tests/api/test_notify_throttled_clients.py
+++ b/tests/api/test_notify_throttled_clients.py
@@ -1,10 +1,14 @@
+import io
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
+from django.utils import timezone
 
 from api.client_health import RepeatOffender
 from api.models import ThrottleNotice
+from users.models import ApiToken
 
 COMMAND = "notify_throttled_clients"
 
@@ -13,6 +17,18 @@ def _offender(user, **overrides):
     defaults = {"days_throttled": 3, "total_count": 15, "worst_day_count": 5}
     defaults.update(overrides)
     return RepeatOffender(username=user.username, **defaults)
+
+
+def _add_prior_notices(user, count):
+    """Create `count` ThrottleNotice rows for `user`, backdated outside the
+    default cooldown window so they don't get skipped as "too recent"."""
+    for _ in range(count):
+        notice = ThrottleNotice.objects.create(
+            user=user, days_throttled=3, total_count=15, worst_day_count=5
+        )
+        ThrottleNotice.objects.filter(pk=notice.pk).update(
+            sent_at=timezone.now() - timedelta(days=10)
+        )
 
 
 @pytest.fixture
@@ -96,3 +112,87 @@ def test_no_candidates_does_not_notify_pushover(mailoutbox, mock_send_pushover):
 
     assert len(mailoutbox) == 0
     mock_send_pushover.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# --enforce
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_enforce_revokes_tokens_when_present(create_user, mailoutbox, mock_send_pushover):
+    user = create_user(email_confirmed=True)
+    ApiToken.objects.create(user=user, name="test token")
+    _add_prior_notices(user, count=2)  # this run's notice will be the 3rd
+
+    with patch(
+        "api.management.commands.notify_throttled_clients.find_repeat_offenders",
+        return_value=[_offender(user)],
+    ):
+        call_command(COMMAND, send=True, enforce=True)
+
+    user.refresh_from_db()
+    assert user.is_active is True
+    assert user.auth_token_set.count() == 0
+    assert len(mailoutbox) == 1
+    assert "restricted" in mailoutbox[0].subject
+    assert ThrottleNotice.objects.filter(user=user).count() == 3
+
+
+@pytest.mark.django_db
+def test_enforce_disables_account_when_no_tokens(create_user, mailoutbox, mock_send_pushover):
+    user = create_user(email_confirmed=True)
+    _add_prior_notices(user, count=2)
+
+    with patch(
+        "api.management.commands.notify_throttled_clients.find_repeat_offenders",
+        return_value=[_offender(user)],
+    ):
+        call_command(COMMAND, send=True, enforce=True)
+
+    user.refresh_from_db()
+    assert user.is_active is False
+    assert len(mailoutbox) == 1
+    assert "restricted" in mailoutbox[0].subject
+
+
+@pytest.mark.django_db
+def test_enforce_not_applied_before_enforce_after_threshold(
+    create_user, mailoutbox, mock_send_pushover
+):
+    user = create_user(email_confirmed=True)
+    _add_prior_notices(user, count=1)  # only 1 prior notice, default enforce_after is 2
+
+    with patch(
+        "api.management.commands.notify_throttled_clients.find_repeat_offenders",
+        return_value=[_offender(user)],
+    ):
+        call_command(COMMAND, send=True, enforce=True)
+
+    user.refresh_from_db()
+    assert user.is_active is True
+    assert len(mailoutbox) == 1
+    assert "rate-limited" in mailoutbox[0].subject
+
+
+@pytest.mark.django_db
+def test_report_mode_previews_enforcement_without_side_effects(
+    create_user, mailoutbox, mock_send_pushover
+):
+    user = create_user(email_confirmed=True)
+    ApiToken.objects.create(user=user, name="test token")
+    _add_prior_notices(user, count=2)
+
+    out = io.StringIO()
+    with patch(
+        "api.management.commands.notify_throttled_clients.find_repeat_offenders",
+        return_value=[_offender(user)],
+    ):
+        call_command(COMMAND, enforce=True, stdout=out)
+
+    user.refresh_from_db()
+    assert "Would enforce (revoke tokens)" in out.getvalue()
+    assert user.is_active is True
+    assert user.auth_token_set.count() == 1
+    assert len(mailoutbox) == 0
+    assert ThrottleNotice.objects.filter(user=user).count() == 2

--- a/tests/api/test_notify_throttled_clients.py
+++ b/tests/api/test_notify_throttled_clients.py
@@ -66,6 +66,8 @@ def test_send_flag_emails_eligible_candidate_and_records_notice(
 
     assert len(mailoutbox) == 1
     assert mailoutbox[0].to == [user.email]
+    assert "15 rate-limited (429) responses" in mailoutbox[0].body
+    assert "3 days" in mailoutbox[0].body
     notice = ThrottleNotice.objects.get(user=user)
     assert notice.days_throttled == 3
     assert notice.total_count == 15
@@ -136,6 +138,7 @@ def test_enforce_revokes_tokens_when_present(create_user, mailoutbox, mock_send_
     assert user.auth_token_set.count() == 0
     assert len(mailoutbox) == 1
     assert "restricted" in mailoutbox[0].subject
+    assert "15 rate-limited (429) responses" in mailoutbox[0].body
     assert ThrottleNotice.objects.filter(user=user).count() == 3
 
 


### PR DESCRIPTION
## Summary

Follow-up to the throttle/auth-method tracking added in #577/#578. Adds an escalation path for accounts whose API client keeps getting rate limited without backing off, on top of the existing `notify_throttled_clients --send` warning email.

- **New `--enforce` flag**: once an account already has `--enforce-after` (default 2) prior warning notices, its next qualifying notice escalates
  instead of warning again:
  - If the account has any API tokens, they're all revoked.
  - Otherwise, the account is disabled (`is_active=False`), which blocks Basic, Session, and Token auth together - so a disabled account drops out of future candidate lists on its own.
- Like `--send`, `--enforce` alone (without `--send`) only *previews* the action per candidate ("Would enforce (revoke tokens)") - nothing is mutated or emailed until both flags are set.
- New `throttle_enforcement_email` template tells the user which action was taken.
- Both the standard warning email and the enforcement email now include the actual violation counts that triggered them (e.g. "15 rate-limited (429) responses across 3 days, including 5 in a single day"), instead of a vague description.
- Documented in `DEPLOYMENT.md` under a new "Escalating to enforcement" section.
