### PR TITLE
Prevent re-notifying accounts for spikes already covered by a notice

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -987,6 +987,14 @@ Sent notices are visible (read-only) in Django admin under API > Throttle notice
 no timer wired up for this yet - run it by hand, or add a systemd timer in report-only mode
 the same way as `metron-opencollective-sync.timer` above if periodic review is wanted.
 
+The trigger only looks at the trailing `--lookback-days` window (default 7, and since the
+cutoff is inclusive it's really an 8-day span), so a spike could otherwise still be inside
+that window on a later run and get reported again for the same data. To prevent that, any
+Redis day on or before a user's most recent `ThrottleNotice` date is excluded from every
+later run for that user - only new throttling after that date can trigger a subsequent
+notice. This is what makes it safe to eventually run on a daily (or any) timer without
+double-reporting the same spike.
+
 ### Escalating to enforcement
 
 Add `--enforce` to escalate instead of sending another plain warning once an account

--- a/api/client_health.py
+++ b/api/client_health.py
@@ -10,7 +10,7 @@ import logging
 import re
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from django.core.cache import cache
 
@@ -66,6 +66,7 @@ def find_repeat_offenders(
     min_days: int = 3,
     single_day_threshold: int = 50,
     extreme_day_threshold: int = 100,
+    exclude_through: dict[str, date] | None = None,
 ) -> list[RepeatOffender]:
     """Scan the throttled-request counters for accounts that keep getting
     rate-limited without backing off. Flags an account if either is true, within
@@ -79,10 +80,18 @@ def find_repeat_offenders(
     IP-only identities (unauthenticated requests) are skipped - there's no
     account to contact.
 
+    `exclude_through` optionally maps username -> a date; any counter dated on
+    or before that date is ignored for that user. Pass each user's most recent
+    ThrottleNotice date here so a spike that already triggered a notice can't
+    trigger a second one purely because the trailing lookback window still
+    happens to overlap it (e.g. a weekly run 7 days after a spike, or any run
+    the same day a notice was just sent).
+
     Django's cache framework has no key-scanning API, so this drops to the
     underlying redis-py client (the same one the cache backend itself uses) to
     SCAN for matching keys.
     """
+    exclude_through = exclude_through or {}
     cutoff = (datetime.now(UTC) - timedelta(days=lookback_days)).date()
     client = cache._cache.get_client(write=False)
 
@@ -101,11 +110,15 @@ def find_repeat_offenders(
         if day < cutoff:
             continue
 
+        username = match["username"]
+        already_notified_through = exclude_through.get(username)
+        if already_notified_through is not None and day <= already_notified_through:
+            continue
+
         value = client.get(raw_key)
         if value is None:
             continue
 
-        username = match["username"]
         daily_counts_by_user[username][date_str] = daily_counts_by_user[username].get(
             date_str, 0
         ) + int(value)

--- a/api/management/commands/notify_throttled_clients.py
+++ b/api/management/commands/notify_throttled_clients.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.core.mail import EmailMultiAlternatives
 from django.core.management.base import BaseCommand
+from django.db.models import Max
 from django.template.loader import render_to_string
 from django.utils import timezone
 
@@ -90,11 +91,22 @@ class Command(BaseCommand):
         enforce = options["enforce"]
         cooldown_cutoff = timezone.now() - timedelta(days=options["cooldown_days"])
 
+        # A username's most recent notice date, so a spike that already triggered
+        # a notice can't trigger another purely because the trailing lookback
+        # window still happens to overlap it.
+        exclude_through = {
+            row["user__username"]: row["latest"].date()
+            for row in ThrottleNotice.objects.values("user__username").annotate(
+                latest=Max("sent_at")
+            )
+        }
+
         offenders = find_repeat_offenders(
             lookback_days=options["lookback_days"],
             min_days=options["min_days"],
             single_day_threshold=options["single_day_threshold"],
             extreme_day_threshold=options["extreme_day_threshold"],
+            exclude_through=exclude_through,
         )
 
         candidates = []

--- a/tests/api/test_client_health.py
+++ b/tests/api/test_client_health.py
@@ -203,3 +203,53 @@ def test_sums_counts_across_scopes_for_the_same_day():
     assert len(matches) == 1
     assert matches[0].days_throttled == 1
     assert matches[0].total_count == 7
+
+
+def test_exclude_through_hides_a_day_already_covered_by_a_prior_notice():
+    # Reproduces the real bug: a spike from 7 days ago still sits inside a later
+    # run's lookback window and would otherwise get reported a second time.
+    username = _unique()
+    spike_day = (datetime.now(UTC) - timedelta(days=7)).date()
+    _set_count("sustained", f"user:{username}", days_ago=7, count=1000)
+
+    offenders = find_repeat_offenders(
+        lookback_days=7,
+        min_days=1,
+        single_day_threshold=1,
+        exclude_through={username: spike_day},
+    )
+
+    assert all(o.username != username for o in offenders)
+
+
+def test_exclude_through_does_not_hide_days_after_the_cutoff():
+    username = _unique()
+    _set_count("sustained", f"user:{username}", days_ago=0, count=1000)
+    # Notice cutoff is yesterday, so today's spike is still new and unreported.
+    yesterday = (datetime.now(UTC) - timedelta(days=1)).date()
+
+    offenders = find_repeat_offenders(
+        lookback_days=7,
+        min_days=1,
+        single_day_threshold=1,
+        exclude_through={username: yesterday},
+    )
+
+    matches = [o for o in offenders if o.username == username]
+    assert len(matches) == 1
+
+
+def test_exclude_through_only_affects_the_named_user():
+    username = _unique()
+    other_username = _unique()
+    _set_count("sustained", f"user:{username}", days_ago=0, count=1000)
+
+    offenders = find_repeat_offenders(
+        lookback_days=7,
+        min_days=1,
+        single_day_threshold=1,
+        exclude_through={other_username: datetime.now(UTC).date()},
+    )
+
+    matches = [o for o in offenders if o.username == username]
+    assert len(matches) == 1

--- a/tests/api/test_notify_throttled_clients.py
+++ b/tests/api/test_notify_throttled_clients.py
@@ -117,6 +117,53 @@ def test_no_candidates_does_not_notify_pushover(mailoutbox, mock_send_pushover):
 
 
 # ---------------------------------------------------------------------------
+# exclude_through wiring - prevents re-reporting a spike a prior notice
+# already covered, purely because the lookback window still overlaps it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_passes_latest_notice_date_per_user_as_exclude_through(
+    create_user, mailoutbox, mock_send_pushover
+):
+    user = create_user(email_confirmed=True)
+    older_notice = ThrottleNotice.objects.create(
+        user=user, days_throttled=1, total_count=100, worst_day_count=100
+    )
+    ThrottleNotice.objects.filter(pk=older_notice.pk).update(
+        sent_at=timezone.now() - timedelta(days=20)
+    )
+    latest_notice = ThrottleNotice.objects.create(
+        user=user, days_throttled=1, total_count=200, worst_day_count=200
+    )
+    ThrottleNotice.objects.filter(pk=latest_notice.pk).update(
+        sent_at=timezone.now() - timedelta(days=10)
+    )
+    latest_notice.refresh_from_db()
+
+    with patch(
+        "api.management.commands.notify_throttled_clients.find_repeat_offenders",
+        return_value=[],
+    ) as mock_find:
+        call_command(COMMAND)
+
+    assert mock_find.call_args.kwargs["exclude_through"] == {
+        user.username: latest_notice.sent_at.date()
+    }
+
+
+@pytest.mark.django_db
+def test_exclude_through_omits_users_with_no_prior_notices(mock_send_pushover):
+    with patch(
+        "api.management.commands.notify_throttled_clients.find_repeat_offenders",
+        return_value=[],
+    ) as mock_find:
+        call_command(COMMAND)
+
+    assert mock_find.call_args.kwargs["exclude_through"] == {}
+
+
+# ---------------------------------------------------------------------------
 # --enforce
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to the throttle-notification work in #579 (found while doing real-world testing: an account was flagged with the exact same stats two runs in a row, a week apart).

`find_repeat_offenders()` only evaluates the trailing `--lookback-days` indow with no memory of what was already reported. Because the cutoff is inclusive, that window is really 8 days wide, so a single spike could still be inside a later run's window and get reported a second time for the same data - e.g. a weekly run exactly 7 days after the spike, or any run later the same day a notice was just sent.

- `find_repeat_offenders()` now accepts `exclude_through: dict[str, date]`
  - any counter dated on or before a user's mapped date is ignored.
- `notify_throttled_clients` builds this automatically from each user's most recent `ThrottleNotice.sent_at` (one `Max()` query) and passes it in on every run, so a spike that already triggered a notice can never trigger a second one - only new throttling after the last notice counts.
- This is what makes it safe to eventually move the command to a daily systemd timer (the intended next step, pending more manual testing) without double-reporting the same incident.
- Documented in `DEPLOYMENT.md` alongside the existing trigger explanation.

