### PR TITLE
Add per-IP rate limiting on account signups

### DIFF
--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -1,4 +1,6 @@
 import time
+import uuid
+from unittest.mock import patch
 
 import pytest
 from django.core.cache import cache
@@ -7,13 +9,14 @@ from pytest_django.asserts import assertTemplateUsed
 
 from users.forms import CustomUserChangeForm
 from users.models import ApiToken, CustomUser, SignupSettings
-from users.views import SUSTAINED_DURATION, SUSTAINED_LIMIT, get_rate_limit_usage
+from users.views import SIGNUP_IP_LIMIT, SUSTAINED_DURATION, SUSTAINED_LIMIT, get_rate_limit_usage
 
 HTTP_NOT_FOUND_CODE = 404
 
 HTML_REDIRECT_MOVED_PERMAMENTLY_CODE = 301
 HTTP_REDIRECT_FOUND_CODE = 302
 HTML_OK_CODE = 200
+HTTP_TOO_MANY_REQUESTS_CODE = 429
 
 
 @pytest.mark.parametrize("url", ["/accounts/update/", "/accounts/password/", "/accounts/signup/"])
@@ -83,6 +86,123 @@ def test_signup_view_disabled_blocks_post(db, client):
     assert resp.status_code == HTML_OK_CODE
     assertTemplateUsed(resp, "registration/signups_disabled.html")
     assert CustomUser.objects.count() == user_count_before
+
+
+def _signup_payload(suffix):
+    return {
+        "username": f"newuser{suffix}",
+        "email": f"newuser{suffix}@gmail.com",
+        "password1": "some-strong-password-1",
+        "password2": "some-strong-password-1",
+    }
+
+
+def _unique_ip():
+    # Unique-per-call identity (rather than a fixed address or a narrow
+    # 0-255 range) so repeated local runs against the real (shared) cache
+    # backend, and other tests in the same run, can't collide on the same
+    # rate-limit bucket - mirrors tests/api/test_client_health.py, but with
+    # a wider ID space since SIGNUP_IP_LIMIT is small enough that even one
+    # coincidental collision would trip the limit early.
+    return f"203.0.113.{uuid.uuid4().hex}"
+
+
+def test_signup_ip_rate_limit_allows_up_to_limit(db, client):
+    ip = _unique_ip()
+    user_count_before = CustomUser.objects.count()
+    with (
+        patch("users.views.get_recaptcha_auth", return_value={"success": True}),
+        patch("users.views.send_pushover"),
+    ):
+        for i in range(SIGNUP_IP_LIMIT):
+            resp = client.post(reverse("signup"), _signup_payload(i), REMOTE_ADDR=ip)
+            assert resp.status_code == HTTP_REDIRECT_FOUND_CODE
+    assert CustomUser.objects.count() == user_count_before + SIGNUP_IP_LIMIT
+
+
+def test_signup_ip_rate_limit_blocks_after_limit(db, client):
+    ip = _unique_ip()
+    with (
+        patch("users.views.get_recaptcha_auth", return_value={"success": True}),
+        patch("users.views.send_pushover") as mock_pushover,
+    ):
+        for i in range(SIGNUP_IP_LIMIT):
+            client.post(reverse("signup"), _signup_payload(i), REMOTE_ADDR=ip)
+        user_count_before = CustomUser.objects.count()
+        mock_pushover.reset_mock()
+
+        resp = client.post(reverse("signup"), _signup_payload("extra"), REMOTE_ADDR=ip)
+
+    assert resp.status_code == HTTP_TOO_MANY_REQUESTS_CODE
+    assertTemplateUsed(resp, "registration/signup_rate_limited.html")
+    assert CustomUser.objects.count() == user_count_before
+    mock_pushover.assert_called_once()
+    message = mock_pushover.call_args[0][0]
+    assert ip in message
+    assert "newuser0" in message  # username of the first signup from this IP
+
+
+def test_signup_ip_rate_limit_notifies_once_per_ip_per_day(db, client):
+    ip = _unique_ip()
+    with (
+        patch("users.views.get_recaptcha_auth", return_value={"success": True}),
+        patch("users.views.send_pushover") as mock_pushover,
+    ):
+        for i in range(SIGNUP_IP_LIMIT):
+            client.post(reverse("signup"), _signup_payload(i), REMOTE_ADDR=ip)
+        mock_pushover.reset_mock()
+
+        # Two blocked attempts in a row from the same IP should only notify once.
+        client.post(reverse("signup"), _signup_payload("extra-1"), REMOTE_ADDR=ip)
+        client.post(reverse("signup"), _signup_payload("extra-2"), REMOTE_ADDR=ip)
+
+    mock_pushover.assert_called_once()
+
+
+def test_signup_ip_rate_limit_is_per_ip(db, client):
+    busy_ip = _unique_ip()
+    other_ip = _unique_ip()
+    with (
+        patch("users.views.get_recaptcha_auth", return_value={"success": True}),
+        patch("users.views.send_pushover"),
+    ):
+        for i in range(SIGNUP_IP_LIMIT):
+            client.post(reverse("signup"), _signup_payload(i), REMOTE_ADDR=busy_ip)
+
+        resp = client.post(reverse("signup"), _signup_payload("other-ip"), REMOTE_ADDR=other_ip)
+
+    assert resp.status_code == HTTP_REDIRECT_FOUND_CODE
+
+
+def test_signup_ip_rate_limit_prefers_x_real_ip_over_remote_addr(db, client):
+    # Simulates sitting behind nginx (nginx/nginx.conf), which sets X-Real-IP
+    # to its own view of the connecting client and REMOTE_ADDR to nginx's own
+    # address. Two requests presented with the same X-Real-IP but different
+    # REMOTE_ADDR should share one rate-limit bucket.
+    real_ip = _unique_ip()
+    user_count_before = CustomUser.objects.count()
+    with (
+        patch("users.views.get_recaptcha_auth", return_value={"success": True}),
+        patch("users.views.send_pushover"),
+    ):
+        for i in range(SIGNUP_IP_LIMIT):
+            resp = client.post(
+                reverse("signup"),
+                _signup_payload(i),
+                REMOTE_ADDR=_unique_ip(),
+                HTTP_X_REAL_IP=real_ip,
+            )
+            assert resp.status_code == HTTP_REDIRECT_FOUND_CODE
+
+        resp = client.post(
+            reverse("signup"),
+            _signup_payload("extra"),
+            REMOTE_ADDR=_unique_ip(),
+            HTTP_X_REAL_IP=real_ip,
+        )
+
+    assert resp.status_code == HTTP_TOO_MANY_REQUESTS_CODE
+    assert CustomUser.objects.count() == user_count_before + SIGNUP_IP_LIMIT
 
 
 def test_profile_view_url_exists_at_desired_location(auto_login_user):

--- a/users/templates/registration/signup_rate_limited.html
+++ b/users/templates/registration/signup_rate_limited.html
@@ -1,0 +1,36 @@
+{% extends parent_template|default:"base.html" %}
+{% block title %}
+    Too Many Signups - Metron
+{% endblock title %}
+{% block content %}
+    <header class="block has-text-centered mt-6">
+        <span class="icon is-large has-text-warning">
+            <i class="fas fa-hourglass-half fa-4x"></i>
+        </span>
+        <h1 class="title is-3 mt-4">Too Many Signups</h1>
+    </header>
+    <div class="columns is-centered">
+        <div class="column is-half">
+            <div class="box">
+                <article class="message is-warning">
+                    <div class="message-body">
+                        <p>
+                            Too many accounts have recently been created from your network. Please try again later.
+                        </p>
+                    </div>
+                </article>
+                <div class="content has-text-centered mt-5">
+                    <div class="buttons is-centered">
+                        <a class="button is-link is-medium" href="{% url 'login' %}">Log In</a>
+                        <a class="button is-link is-medium is-outlined" href="{% url 'home' %}">
+                            <span class="icon">
+                                <i class="fas fa-home"></i>
+                            </span>
+                            <span>Go to Home</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/users/views.py
+++ b/users/views.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from datetime import date
 
 from django.contrib import messages
 from django.contrib.auth import login, logout, update_session_auth_hash
@@ -42,6 +43,53 @@ logger = logging.getLogger(__name__)
 PAGINATE_BY = 28
 SUSTAINED_LIMIT = 5000
 SUSTAINED_DURATION = 86400  # 1 day in seconds
+SIGNUP_IP_LIMIT = 1
+SIGNUP_IP_WINDOW = 60 * 60 * 25  # 1 day + an hour of cleanup headroom
+
+
+def _client_ip(request):
+    # nginx (nginx/nginx.conf) always overwrites X-Real-IP with its own
+    # observed connecting address, so it's safe to trust - unlike
+    # X-Forwarded-For, which nginx appends to rather than replaces, so it can
+    # carry a client-supplied prefix. Falls back to REMOTE_ADDR for local dev
+    # (runserver with no proxy in front, where there's no X-Real-IP header).
+    return request.META.get("HTTP_X_REAL_IP") or request.META.get("REMOTE_ADDR", "unknown")
+
+
+def _signup_ip_key(prefix, request):
+    return f"{prefix}:ip:{_client_ip(request)}:{date.today().isoformat()}"
+
+
+def _signup_ip_count(request):
+    return cache.get(_signup_ip_key("signup_count", request), 0)
+
+
+def _record_signup(request, username):
+    key = _signup_ip_key("signup_count", request)
+    cache.add(key, 0, timeout=SIGNUP_IP_WINDOW)
+    cache.incr(key)
+    # Only the first signup from this IP/day wins - cache.add is a no-op if
+    # a username is already recorded.
+    cache.add(_signup_ip_key("signup_first_user", request), username, timeout=SIGNUP_IP_WINDOW)
+
+
+def _notify_signup_rate_limit_hit(request):
+    ip = _client_ip(request)
+    count = _signup_ip_count(request)
+    first_user = cache.get(_signup_ip_key("signup_first_user", request), "unknown")
+    # cache.add only succeeds the first time per IP/day, so repeated blocked
+    # retries from the same client don't spam a pushover notice each time.
+    notified_key = _signup_ip_key("signup_rate_limit_notified", request)
+    if cache.add(notified_key, True, timeout=SIGNUP_IP_WINDOW):
+        logger.warning(
+            "Signup rate limit hit for IP %s (%d accounts today, first: %s)",
+            ip,
+            count,
+            first_user,
+        )
+        send_pushover(
+            f"Signup rate limit hit for {ip} ({count} accounts created today, first: {first_user})."
+        )
 
 
 def is_activated(user, token):
@@ -89,6 +137,10 @@ def signup(request):  # sourcery skip: extract-method
         )
 
     if request.method == "POST":
+        if _signup_ip_count(request) >= SIGNUP_IP_LIMIT:
+            _notify_signup_rate_limit_hit(request)
+            return render(request, "registration/signup_rate_limited.html", status=429)
+
         form = CustomUserCreationForm(request.POST)
         if form.is_valid():
             result = get_recaptcha_auth(request)
@@ -97,6 +149,7 @@ def signup(request):  # sourcery skip: extract-method
                 user: CustomUser = form.save(commit=False)
                 user.is_active = False
                 user.save()
+                _record_signup(request, user.username)
                 current_site = get_current_site(request)
                 subject = "Activate Your Metron Account"
                 context = {


### PR DESCRIPTION
## Summary
- Caps new account creation at `SIGNUP_IP_LIMIT` per IP per day, using the same Redis-backed cache counter pattern already used for API throttling in `api/client_health.py`
- Checked before form processing (so an already-limited client doesn't even trigger hCaptcha/email-domain validation) and only incremented after an account is actually created — failed attempts don't count against the limit
- Resolves client IP via `X-Real-IP` first (set unconditionally by nginx, so it can't be spoofed) falling back to `REMOTE_ADDR` for local dev, since Django sees the proxy's own address otherwise
- Sends a Pushover alert (capped at one per IP per day) when an IP hits the limit, including the username of the first account created from that IP, so it can be followed up on if needed
- Renders a friendly `signup_rate_limited.html` page (HTTP 429) instead of a bare error

## Motivation
Complements the admin-controlled signup toggle from #587. That's an all-or-nothing switch — closing signups for everyone to stop a handful of duplicate accounts is a blunt instrument. This adds a softer, always-on layer that targets the actual duplicate-account behavior without ever needing to close signups to legitimate new users.
