### PR TITLE
Fix empty sort dropdown on secondary issue list views

### DIFF
--- a/comicsdb/views/arc.py
+++ b/comicsdb/views/arc.py
@@ -12,6 +12,7 @@ from comicsdb.models.arc import Arc
 from comicsdb.models.issue import Issue
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
+from comicsdb.views.issue_list_helpers import SORT_OPTIONS, apply_sort
 from comicsdb.views.mixins import (
     AttributionCreateMixin,
     AttributionUpdateMixin,
@@ -43,11 +44,14 @@ class ArcIssueList(ListView):
 
     def get_queryset(self):
         self.arc = get_object_or_404(Arc, slug=self.kwargs["slug"])
-        return self.arc.issues.all().select_related("series", "series__series_type")
+        queryset = self.arc.issues.all().select_related("series", "series__series_type")
+        return apply_sort(queryset, self.request)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = self.arc
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 

--- a/comicsdb/views/character.py
+++ b/comicsdb/views/character.py
@@ -11,6 +11,7 @@ from comicsdb.forms.character import CharacterForm
 from comicsdb.models import Character, Issue, Series
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
+from comicsdb.views.issue_list_helpers import SORT_OPTIONS, apply_sort
 from comicsdb.views.mixins import (
     AttributionCreateMixin,
     AttributionUpdateMixin,
@@ -31,9 +32,16 @@ class CharacterSeriesList(ListView):
         self.series = get_object_or_404(Series, slug=self.kwargs["series"])
         self.character = get_object_or_404(Character, slug=self.kwargs["character"])
 
-        return Issue.objects.select_related("series").filter(
+        queryset = Issue.objects.select_related("series").filter(
             characters=self.character, series=self.series
         )
+        return apply_sort(queryset, self.request)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
+        return context
 
 
 _issue_count_qs = (
@@ -56,11 +64,14 @@ class CharacterIssueList(ListView):
 
     def get_queryset(self):
         self.character = get_object_or_404(Character, slug=self.kwargs["slug"])
-        return self.character.issues.all().select_related("series", "series__series_type")
+        queryset = self.character.issues.all().select_related("series", "series__series_type")
+        return apply_sort(queryset, self.request)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = self.character
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 

--- a/comicsdb/views/creator.py
+++ b/comicsdb/views/creator.py
@@ -11,6 +11,7 @@ from comicsdb.forms.creator import CreatorForm
 from comicsdb.models import Creator, Credits, Issue, Series
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
+from comicsdb.views.issue_list_helpers import SORT_OPTIONS, apply_sort
 from comicsdb.views.mixins import (
     AttributionCreateMixin,
     AttributionUpdateMixin,
@@ -37,9 +38,16 @@ class CreatorSeriesList(ListView):
     def get_queryset(self):
         self.series = get_object_or_404(Series, slug=self.kwargs["series"])
         self.creator = get_object_or_404(Creator, slug=self.kwargs["creator"])
-        return Issue.objects.select_related("series").filter(
+        queryset = Issue.objects.select_related("series").filter(
             creators=self.creator, series=self.series
         )
+        return apply_sort(queryset, self.request)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
+        return context
 
 
 class CreatorIssueList(ListView):
@@ -48,11 +56,14 @@ class CreatorIssueList(ListView):
 
     def get_queryset(self):
         self.creator = get_object_or_404(Creator, slug=self.kwargs["slug"])
-        return self.creator.issues.all().select_related("series", "series__series_type")
+        queryset = self.creator.issues.all().select_related("series", "series__series_type")
+        return apply_sort(queryset, self.request)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = self.creator
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 

--- a/comicsdb/views/series.py
+++ b/comicsdb/views/series.py
@@ -13,6 +13,7 @@ from comicsdb.models import Series, SeriesType
 from comicsdb.models.issue import Issue
 from comicsdb.views.constants import PAGINATE_BY
 from comicsdb.views.history import HistoryListView
+from comicsdb.views.issue_list_helpers import SORT_OPTIONS, apply_sort
 from comicsdb.views.mixins import (
     AttributionCreateMixin,
     AttributionUpdateMixin,
@@ -62,11 +63,14 @@ class SeriesIssueList(ListView):
 
     def get_queryset(self):
         self.series = get_object_or_404(Series, slug=self.kwargs["slug"])
-        return self.series.issues.all()
+        queryset = self.series.issues.all()
+        return apply_sort(queryset, self.request)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = self.series
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 

--- a/comicsdb/views/team.py
+++ b/comicsdb/views/team.py
@@ -12,6 +12,7 @@ from comicsdb.models import Issue
 from comicsdb.models.team import Team
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
+from comicsdb.views.issue_list_helpers import SORT_OPTIONS, apply_sort
 from comicsdb.views.mixins import (
     AttributionCreateMixin,
     AttributionUpdateMixin,
@@ -43,11 +44,14 @@ class TeamIssueList(ListView):
 
     def get_queryset(self):
         self.team = get_object_or_404(Team, slug=self.kwargs["slug"])
-        return self.team.issues.all().select_related("series", "series__series_type")
+        queryset = self.team.issues.all().select_related("series", "series__series_type")
+        return apply_sort(queryset, self.request)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = self.team
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 

--- a/comicsdb/views/universe.py
+++ b/comicsdb/views/universe.py
@@ -13,6 +13,7 @@ from comicsdb.models.team import Team
 from comicsdb.models.universe import Universe
 from comicsdb.views.constants import DETAIL_PAGINATE_BY, PAGINATE_BY
 from comicsdb.views.history import HistoryListView
+from comicsdb.views.issue_list_helpers import SORT_OPTIONS, apply_sort
 from comicsdb.views.mixins import (
     AttributionCreateMixin,
     AttributionUpdateMixin,
@@ -54,9 +55,16 @@ class UniverseSeriesList(ListView):
         self.series = get_object_or_404(Series, slug=self.kwargs["series"])
         self.universe = get_object_or_404(Universe, slug=self.kwargs["universe"])
 
-        return Issue.objects.select_related("series").filter(
+        queryset = Issue.objects.select_related("series").filter(
             universes=self.universe, series=self.series
         )
+        return apply_sort(queryset, self.request)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
+        return context
 
 
 class UniverseList(ListView):
@@ -71,11 +79,14 @@ class UniverseIssueList(ListView):
 
     def get_queryset(self):
         self.universe = get_object_or_404(Universe, slug=self.kwargs["slug"])
-        return self.universe.issues.all().select_related("series", "series__series_type")
+        queryset = self.universe.issues.all().select_related("series", "series__series_type")
+        return apply_sort(queryset, self.request)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = self.universe
+        context["sort_options"] = SORT_OPTIONS
+        context["current_sort"] = self.request.GET.get("sort", "")
         return context
 
 


### PR DESCRIPTION
## Summary
- The issue-sort dropdown (`issue_sort.html`) reads `sort_options`/`current_sort` from context, but only `IssueList`, `WeekList`, `NextWeekList`, and `FutureList` ever set them — every other view rendering `issue_list.html` left the dropdown empty and silently ignored the `?sort=` param.
- Wired the shared `SORT_OPTIONS`/`apply_sort` helpers (from `issue_list_helpers.py`) into the remaining affected views: `SeriesIssueList`, `ArcIssueList`, `CreatorSeriesList`, `CreatorIssueList`, `CharacterSeriesList`, `CharacterIssueList`, `UniverseSeriesList`, `UniverseIssueList`, and `TeamIssueList`.
