### PR TITLE
Fix duplicate read-date calendar widgets on collection item detail page

### DIFF
--- a/user_collection/templates/user_collection/collection_detail.html
+++ b/user_collection/templates/user_collection/collection_detail.html
@@ -199,10 +199,16 @@
     <script src="{% static 'extensions/bulma-calendar/dist/js/bulma-calendar.min.js' %}"></script>
     <script>
         // Initialize Bulma Calendar for datetime inputs
-        function initializeDateTimePickers() {
-            var calendarInputs = document.querySelectorAll('input[data-bulma-calendar="on"]');
+        function initializeDateTimePickers(root) {
+            var calendarInputs = (root || document).querySelectorAll('input[data-bulma-calendar="on"]');
 
             calendarInputs.forEach(function(input) {
+                // bulmaCalendar's own "already attached" guard is broken, so
+                // skip inputs we've already initialized ourselves.
+                if (input.bulmaCalendar) {
+                    return;
+                }
+
                 var dataType = input.getAttribute('data-type');
                 var isDateTime = dataType === 'datetime';
 
@@ -227,9 +233,13 @@
         }
 
         // Initialize on page load
-        document.addEventListener('DOMContentLoaded', initializeDateTimePickers);
+        document.addEventListener('DOMContentLoaded', function() {
+            initializeDateTimePickers(document);
+        });
 
-        // Re-initialize after HTMX swaps content
-        document.body.addEventListener('htmx:afterSwap', initializeDateTimePickers);
+        // Re-initialize only the content HTMX just swapped in
+        document.body.addEventListener('htmx:afterSwap', function(evt) {
+            initializeDateTimePickers(evt.detail.target);
+        });
     </script>
 {% endblock %}


### PR DESCRIPTION
## Problem

On the collection item detail page, rating an issue (or any other HTMX swap on the page) caused an extra read-date calendar widget to be stacked on top of the existing one.

## Root cause

The `htmx:afterSwap` listener was bound on `document.body` and fired for every HTMX swap on the page, including ones unrelated to the read-date widget (e.g. the star-rating swap). Each firing re-scanned the *entire document* for `input[data-bulma-calendar="on"]` elements and re-attached bulmaCalendar to them.

Normally bulmaCalendar's own "already attached" check would make re-attaching a no-op, but that check is broken in the vendored library (it reads `this.constructor.name` inside a `static` method, which evaluates to `"Function"` rather than the class name), so every re-init call created a brand-new calendar widget instead of skipping.

## Fix

- Scope the `htmx:afterSwap` handler to only re-scan the fragment HTMX just swapped in (`evt.detail.target`), instead of the whole document.
- Add our own `input.bulmaCalendar` guard before calling `attach()`, since the library's built-in guard doesn't work.
